### PR TITLE
count lread in automic op merging

### DIFF
--- a/src/io/default_compact_strategy.cc
+++ b/src/io/default_compact_strategy.cc
@@ -118,9 +118,12 @@ bool DefaultCompactStrategy::Drop(const leveldb::Slice& tera_key, uint64_t n) {
     return false;
 }
 
-bool DefaultCompactStrategy::ScanMergedValue(leveldb::Iterator* it, std::string* merged_value) {
+bool DefaultCompactStrategy::ScanMergedValue(leveldb::Iterator* it,
+                                             std::string* merged_value,
+                                             int64_t* merged_num) {
     std::string merged_key;
-    bool has_merge =  InternalMergeProcess(it, merged_value, &merged_key, true, false);
+    bool has_merge =  InternalMergeProcess(it, merged_value, &merged_key,
+                                           true, false, merged_num);
     return has_merge;
 }
 
@@ -128,12 +131,16 @@ bool DefaultCompactStrategy::MergeAtomicOPs(leveldb::Iterator* it,
                                             std::string* merged_value,
                                             std::string* merged_key) {
     bool merge_put_flag = false; // don't merge the last PUT if we have
-    return InternalMergeProcess(it, merged_value, merged_key, merge_put_flag, true);
+    return InternalMergeProcess(it, merged_value, merged_key, merge_put_flag,
+                                true, NULL);
 }
 
-bool DefaultCompactStrategy::InternalMergeProcess(leveldb::Iterator* it, std::string* merged_value,
+bool DefaultCompactStrategy::InternalMergeProcess(leveldb::Iterator* it,
+                                                  std::string* merged_value,
                                                   std::string* merged_key,
-                                                  bool merge_put_flag, bool is_internal_key) {
+                                                  bool merge_put_flag,
+                                                  bool is_internal_key,
+                                                  int64_t* merged_num) {
     if (!tera::io::IsAtomicOP(m_cur_type)) {
         return false;
     }
@@ -144,10 +151,12 @@ bool DefaultCompactStrategy::InternalMergeProcess(leveldb::Iterator* it, std::st
     atom_merge.Init(merged_key, merged_value, it->key(), it->value(), m_cur_type);
 
     it->Next();
+    int64_t merged_num_t = 1;
     int64_t last_ts_atomic = m_cur_ts;
     int64_t version_num = 0;
 
     while (it->Valid()) {
+        merged_num_t++;
         if (version_num >= 1) {
             break; //avoid accumulate to many versions
         }
@@ -191,6 +200,9 @@ bool DefaultCompactStrategy::InternalMergeProcess(leveldb::Iterator* it, std::st
         it->Next();
     }
     atom_merge.Finish();
+    if (merged_num) {
+        *merged_num = merged_num_t;
+    }
     return true;
 }
 

--- a/src/io/default_compact_strategy.h
+++ b/src/io/default_compact_strategy.h
@@ -26,7 +26,9 @@ public:
 
     virtual const char* Name() const;
 
-    virtual bool ScanMergedValue(leveldb::Iterator* it, std::string* merged_value);
+    virtual bool ScanMergedValue(leveldb::Iterator* it,
+                                 std::string* merged_value,
+                                 int64_t* merged_num = NULL);
 
     virtual bool MergeAtomicOPs(leveldb::Iterator* it, std::string* merged_value,
                                 std::string* merged_key);
@@ -38,7 +40,8 @@ private:
 
     bool InternalMergeProcess(leveldb::Iterator* it, std::string* merged_value,
                               std::string* merged_key,
-                              bool merge_put_flag, bool is_internal_key);
+                              bool merge_put_flag, bool is_internal_key,
+                              int64_t* merged_num);
 
 private:
     std::map<std::string, int32_t> m_cf_indexs;

--- a/src/io/tablet_io.cc
+++ b/src/io/tablet_io.cc
@@ -707,9 +707,12 @@ inline bool TabletIO::LowLevelScan(const std::string& start_tera_key,
             last_col.assign(col.data(), col.size());
             last_qual.assign(qual.data(), qual.size());
             version_num = 1;
-            has_merged = compact_strategy->ScanMergedValue(it, &merged_value);
+            int64_t merged_num;
+            has_merged =
+                compact_strategy->ScanMergedValue(it, &merged_value, &merged_num);
             VLOG(10) << "has_merged:" << has_merged;
             if (has_merged) {
+                m_counter.low_read_cell.Add(merged_num);
                 value = merged_value;
                 key = last_key;
                 col = last_col;
@@ -1370,7 +1373,7 @@ void TabletIO::TearDownIteratorOptions(leveldb::ReadOptions* opts) {
 }
 
 static bool CheckValue(const KeyValuePair& kv, const Filter& filter) {
-    int64_t v1 = *(int64_t*)kv.value().c_str(); 
+    int64_t v1 = *(int64_t*)kv.value().c_str();
     int64_t v2 = *(int64_t*)filter.ref_value().c_str();
     BinCompOp op = filter.bin_comp_op();
     switch (op) {
@@ -1395,7 +1398,7 @@ static bool CheckValue(const KeyValuePair& kv, const Filter& filter) {
     default:
         LOG(ERROR) << "illegal compare operator: " << op;
     }
-    return false; 
+    return false;
 }
 
 static bool CheckCell(const KeyValuePair& kv, const Filter& filter) {
@@ -1406,7 +1409,7 @@ static bool CheckCell(const KeyValuePair& kv, const Filter& filter) {
                 return false;
             }
         } else {
-            LOG(ERROR) << "only support value-compare."; 
+            LOG(ERROR) << "only support value-compare.";
         }
         break;
     }

--- a/src/io/ttlkv_compact_strategy.cc
+++ b/src/io/ttlkv_compact_strategy.cc
@@ -61,7 +61,8 @@ bool KvCompactStrategy::ScanDrop(const leveldb::Slice& tera_key, uint64_t n) {
     return Drop(tera_key, n); // used in scan.
 }
 
-bool KvCompactStrategy::ScanMergedValue(Iterator* it, std::string* merged_value) {
+bool KvCompactStrategy::ScanMergedValue(Iterator* it, std::string* merged_value,
+                                        int64_t* merged_num) {
     return false;
 }
 

--- a/src/io/ttlkv_compact_strategy.h
+++ b/src/io/ttlkv_compact_strategy.h
@@ -23,7 +23,8 @@ public:
     // used in LowLevelScan
     virtual bool ScanDrop(const leveldb::Slice& k, uint64_t n);
 
-    virtual bool ScanMergedValue(leveldb::Iterator* it, std::string* merged_value);
+    virtual bool ScanMergedValue(leveldb::Iterator* it, std::string* merged_value,
+                                 int64_t* merged_num);
 
     virtual bool MergeAtomicOPs(leveldb::Iterator* it, std::string* merged_value,
                                 std::string* merged_key);

--- a/src/leveldb/include/leveldb/compact_strategy.h
+++ b/src/leveldb/include/leveldb/compact_strategy.h
@@ -28,7 +28,8 @@ public:
     // used in LowLevelScan
     virtual bool ScanDrop(const Slice& k, uint64_t n) = 0;
 
-    virtual bool ScanMergedValue(Iterator* it, std::string* merged_value) = 0;
+    virtual bool ScanMergedValue(Iterator* it, std::string* merged_value,
+                                 int64_t* merged_num = NULL) = 0;
 
     virtual bool MergeAtomicOPs(Iterator* it, std::string* merged_value,
                                 std::string* merged_key) = 0;
@@ -58,7 +59,8 @@ public:
         return false;
     }
 
-    virtual bool ScanMergedValue(Iterator* it, std::string* merged_value) {
+    virtual bool ScanMergedValue(Iterator* it, std::string* merged_value,
+                                 int64_t* merged_num) {
         return false;
     }
 };


### PR DESCRIPTION
当前lread里没有记录读counter时merge操作中迭代器操作
发现高频读counter时迭代器消耗是比较高的，暴露出来有助于优化上层逻辑