### PR TITLE
add  admin_group to table schema

### DIFF
--- a/src/proto/table_schema.proto
+++ b/src/proto/table_schema.proto
@@ -52,5 +52,5 @@ message TableSchema {
     optional int64 merge_size = 10; // MB
     optional bool kv_only = 9 [default = false];
     optional bool disable_wal = 11 [default = false];
+    optional string admin_group = 12; // users in admin_group can admin this table 
 }
-

--- a/src/sdk/schema.cc
+++ b/src/sdk/schema.cc
@@ -139,6 +139,14 @@ bool TableDescriptor::IsKv() const {
     return _impl->IsKv();
 }
 
+void TableDescriptor::SetAdminGroup(const std::string& name) {
+    return _impl->SetAdminGroup(name);
+}
+
+std::string TableDescriptor::AdminGroup() const {
+    return _impl->AdminGroup();
+}
+
 } // namespace tera
 
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/sdk/schema_impl.cc
+++ b/src/sdk/schema_impl.cc
@@ -246,6 +246,14 @@ void TableDescImpl::SetKvOnly() {
     _kv_only = true;
 }
 
+void TableDescImpl::SetAdminGroup(const std::string& name) {
+    _admin_group = name;
+}
+
+std::string TableDescImpl::AdminGroup() const {
+    return _admin_group;
+}
+
 /// 增加一个localitygroup
 LocalityGroupDescriptor* TableDescImpl::AddLocalityGroup(const std::string& lg_name) {
     if (_kv_only && _lg_map.size() > 1) {

--- a/src/sdk/schema_impl.h
+++ b/src/sdk/schema_impl.h
@@ -183,6 +183,9 @@ public:
     /// 是否为kv表
     bool IsKv() const;
 
+    void SetAdminGroup(const std::string& name);
+    std::string AdminGroup() const;
+
 private:
     typedef std::map<std::string, LGDescImpl*> LGMap;
     typedef std::map<std::string, CFDescImpl*> CFMap;
@@ -201,6 +204,7 @@ private:
     int64_t         _split_size;
     int64_t         _merge_size;
     bool            _disable_wal;
+    std::string     _admin_group;
 };
 
 } // namespace tera

--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -83,6 +83,9 @@ void ShowTableSchema(const TableSchema& schema, bool is_x) {
         if (is_x || lg_schema.block_size() != FLAGS_tera_tablet_write_block_size) {
             ss << "blocksize=" << lg_schema.block_size() << ",";
         }
+        if (is_x || schema.admin_group() != "") {
+            ss << "admin_group=" << schema.admin_group() << ",";
+        }
         ss << "\b>\n" << "  (kv mode)\n";
         std::cout << ss.str() << std::endl;
         return;
@@ -95,6 +98,9 @@ void ShowTableSchema(const TableSchema& schema, bool is_x) {
     ss << "splitsize=" << schema.split_size() << ",";
     if (is_x || schema.merge_size() != FLAGS_tera_master_merge_tablet_size) {
         ss << "mergesize=" << schema.merge_size() << ",";
+    }
+    if (is_x || schema.admin_group() != "") {
+        ss << "admin_group=" << schema.admin_group() << ",";
     }
     if (is_x || schema.disable_wal()) {
         ss << "wal=" << Switch2Str(!schema.disable_wal()) << ",";
@@ -190,6 +196,7 @@ void TableDescToSchema(const TableDescriptor& desc, TableSchema* schema) {
     schema->set_split_size(desc.SplitSize());
     schema->set_merge_size(desc.MergeSize());
     schema->set_kv_only(desc.IsKv());
+    schema->set_admin_group(desc.AdminGroup());
     schema->set_disable_wal(desc.IsWalDisabled());
 
     // add lg
@@ -255,6 +262,9 @@ void TableSchemaToDesc(const TableSchema& schema, TableDescriptor* desc) {
     }
     if (schema.has_merge_size()) {
         desc->SetMergeSize(schema.merge_size());
+    }
+    if (schema.has_admin_group()) {
+        desc->SetAdminGroup(schema.admin_group());
     }
     if (schema.has_disable_wal() && schema.disable_wal()) {
         desc->DisableWal();
@@ -395,6 +405,18 @@ bool SetLgProperties(const string& name, const string& value,
     return true;
 }
 
+bool IsValidGroupName(const string& name) {
+    const size_t len = name.length();
+    for (size_t i = 0; i < len; ++i) {
+        if (!isalnum(name[i]) && (name[i] != '_')) {
+            return false;
+        }
+    }
+    const size_t kLenMin = 2;
+    const size_t kLenMax = 32;
+    return (kLenMin <= len) && (len <= kLenMax);
+}
+
 bool SetTableProperties(const string& name, const string& value,
                         TableDescriptor* desc) {
     if (name == "rawkey") {
@@ -419,6 +441,11 @@ bool SetTableProperties(const string& name, const string& value,
             return false;
         }
         desc->SetMergeSize(mergesize);
+    } else if (name == "admin_group"){
+        if (!IsValidGroupName(value)) {
+            return false;
+        }
+        desc->SetAdminGroup(value);
     } else if (name == "wal") {
         if (value == "on") {
             // do nothing

--- a/src/sdk/tera.h
+++ b/src/sdk/tera.h
@@ -200,6 +200,10 @@ public:
     void SetKvOnly();
     bool IsKv() const;
 
+    /// acl
+    void SetAdminGroup(const std::string& name);
+    std::string AdminGroup() const;
+
 private:
     TableDescriptor(const TableDescriptor&);
     void operator=(const TableDescriptor&);


### PR DESCRIPTION
在表格的schema中添加管理组(admin_group)字段，以便后续的按组授权。

按照上次讨论的结果，目前只支持一个管理组；

支持多个组会有点麻烦（主要是sdk这边各种set/get操作），以后有需要再支持。