### PR TITLE
issue=#267 drop timeout read

### DIFF
--- a/src/proto/tabletnode_rpc.proto
+++ b/src/proto/tabletnode_rpc.proto
@@ -245,6 +245,7 @@ message ReadTabletRequest {
     //repeated KeyValuePair key_values = 5;
     optional uint64 snapshot_id = 6;
     optional int64 timestamp = 7 [default = 0];
+    optional int64 client_timeout_ms = 8 [default = 0];
 }
 
 message ReadTabletResponse {

--- a/src/sdk/table_impl.h
+++ b/src/sdk/table_impl.h
@@ -430,6 +430,10 @@ private:
     bool _seq_mutation_wait_to_update_meta;
     bool _seq_mutation_wait_to_retry;
     uint64_t _seq_mutation_pending_rpc_count;
+
+    /// read request will contain this member, 
+    /// so tabletnodes can drop the read-request that timeouted
+    uint64_t _pending_timeout_ms;
 };
 
 } // namespace tera

--- a/src/tabletnode/remote_tabletnode.cc
+++ b/src/tabletnode/remote_tabletnode.cc
@@ -348,6 +348,18 @@ void RemoteTabletNode::DoScheduleRpc(RpcSchedule* rpc_schedule) {
     case RPC_READ: {
         ReadRpc* read_rpc = (ReadRpc*)rpc;
         table_name = read_rpc->request->tablet_name();
+        int64_t read_timeout = read_rpc->request->client_timeout_ms() * 1000;// ms -> us
+        int64_t detal = get_micros() - read_rpc->start_micros;
+        if (read_rpc->request->has_client_timeout_ms()
+            && (detal > read_timeout)) {
+            VLOG(5) << "timeout, drop read request for:" << table_name
+                << ", detal(in us):" << detal << ", read_timeout(in us):" << read_timeout;
+            read_rpc->response->set_sequence_id(read_rpc->request->sequence_id());
+            read_rpc->response->set_success_num(0);
+            read_rpc->response->set_status(kTableIsBusy);
+            read_rpc->done->Run();
+            break;
+        }
         DoReadTablet(read_rpc->controller, read_rpc->start_micros,
                      read_rpc->request, read_rpc->response,
                      read_rpc->done,read_rpc->timer);


### PR DESCRIPTION
丢弃在ts的read pending队列中排队时间过长的请求，超时时间由client定义。