### PR TITLE
Revert "Hold lock in TabletIO::GetCompactStatus()"

### DIFF
--- a/src/io/tablet_io.cc
+++ b/src/io/tablet_io.cc
@@ -111,7 +111,6 @@ std::string TabletIO::GetEndKey() const {
 }
 
 CompactStatus TabletIO::GetCompactStatus() const {
-    MutexLock lock(&m_mutex);
     return m_compact_status;
 }
 


### PR DESCRIPTION
Reverts baidu/tera#302

revert了吧，确实没必要。