### PR TITLE
issue=#98 prepare multi-thread-compaction

### DIFF
--- a/src/leveldb/db/db_impl.cc
+++ b/src/leveldb/db/db_impl.cc
@@ -149,6 +149,8 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
       bg_compaction_scheduled_(false),
       bg_compaction_score_(0),
       bg_schedule_id_(0),
+      imm_dump_(false),
+      multi_thread_compaction_(false),
       manual_compaction_(NULL),
       consecutive_compaction_errors_(0),
       flush_on_destroy_(false) {
@@ -165,6 +167,20 @@ DBImpl::DBImpl(const Options& options, const std::string& dbname)
                              &internal_comparator_);
 }
 
+void DBImpl::WaitCompactionDone() {
+  if (multi_thread_compaction_) {
+    // TODO
+  } else {
+    assert(compact_set_.size() <= 1);
+    if (bg_compaction_scheduled_) {
+      env_->ReSchedule(bg_schedule_id_, kDumpMemTableUrgentScore);
+    }
+    while (bg_compaction_scheduled_) {
+      bg_cv_.Wait();
+    }
+  }
+}
+
 Status DBImpl::Shutdown1() {
   assert(state_ == kOpened);
   state_ = kShutdown1;
@@ -173,12 +189,7 @@ Status DBImpl::Shutdown1() {
   shutting_down_.Release_Store(this);  // Any non-NULL value is ok
 
   Log(options_.info_log, "[%s] wait bg compact finish", dbname_.c_str());
-  if (bg_compaction_scheduled_) {
-    env_->ReSchedule(bg_schedule_id_, kDumpMemTableUrgentScore);
-  }
-  while (bg_compaction_scheduled_) {
-    bg_cv_.Wait();
-  }
+  WaitCompactionDone();
 
   Status s;
   if (!options_.dump_mem_on_shutdown) {
@@ -561,7 +572,8 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
 
 Status DBImpl::CompactMemTable() {
   mutex_.AssertHeld();
-  assert(imm_ != NULL);
+  assert(imm_ != NULL && imm_dump_ == false);
+  imm_dump_ = true;
 
   // Save the contents of the memtable as a new Table
   VersionEdit edit;
@@ -593,6 +605,8 @@ Status DBImpl::CompactMemTable() {
     has_imm_.Release_Store(NULL);
   }
 
+  assert(imm_dump_ == true);
+  imm_dump_ = false;
   return s;
 }
 
@@ -764,7 +778,7 @@ Status DBImpl::RecoverLastDumpToLevel0(VersionEdit* edit) {
 
 // end of tera-specific
 
-void DBImpl::MaybeScheduleCompaction() {
+void DBImpl::MaybeScheduleSingleThreadCompaction() {
   mutex_.AssertHeld();
   if (shutting_down_.Acquire_Load()) {
     // DB is being deleted; no more background compactions
@@ -785,11 +799,7 @@ void DBImpl::MaybeScheduleCompaction() {
                 dbname_.c_str(), bg_schedule_id_, score);
             bg_compaction_score_ = score;
         } else {
-            bg_schedule_id_ = env_->Schedule(&DBImpl::BGWork, this, score);
-            Log(options_.info_log, "[%s] Schedule Compact[%ld] score= %.2f",
-                dbname_.c_str(), bg_schedule_id_, score);
-            bg_compaction_score_ = score;
-            bg_compaction_scheduled_ = true;
+            AddCompactTask(score);
         }
     } else {
       // No work to be done
@@ -797,14 +807,54 @@ void DBImpl::MaybeScheduleCompaction() {
   }
 }
 
-void DBImpl::BGWork(void* db) {
-  reinterpret_cast<DBImpl*>(db)->BackgroundCall();
+void DBImpl::AddCompactTask(double score) {
+  mutex_.AssertHeld();
+  CompactTaskInfo *task = new CompactTaskInfo;
+  task->db = this;
+  task->id = env_->Schedule(&DBImpl::BGWork, task, score);
+  compact_set_.insert(task);
+
+  // multi thread compaction doesn't care these 3 members
+  bg_schedule_id_ = task->id;
+  bg_compaction_score_ = score;
+  bg_compaction_scheduled_ = true;
+  Log(options_.info_log, "[%s] add task:%ld, score= %.2f", 
+      dbname_.c_str(), task->id, score);
 }
 
-void DBImpl::BackgroundCall() {
+void DBImpl::DeleteCompactTask(CompactTaskInfo *task) {
+  mutex_.AssertHeld();
+  std::set<CompactTaskInfo*>::iterator it = compact_set_.find(task);
+  if (it == compact_set_.end()) {
+    fprintf(stderr, "[%s] cannot found task id:%ld\n", dbname_.c_str(), task->id);
+    abort();
+  }
+  Log(options_.info_log, "[%s] delete task:%ld", dbname_.c_str(), task->id);
+  delete task;
+  compact_set_.erase(task);
+
+  // multi thread compaction doesn't care this
+  bg_compaction_scheduled_ = false;
+}
+
+void DBImpl::MaybeScheduleCompaction() {
+  if (multi_thread_compaction_) {
+      // TODO
+  } else {
+    assert(compact_set_.size() <= 1);
+    MaybeScheduleSingleThreadCompaction();
+  }
+}
+
+void DBImpl::BGWork(void* task) {
+  CompactTaskInfo *c = reinterpret_cast<CompactTaskInfo*>(task);
+  c->db->BackgroundCall(c);
+}
+
+void DBImpl::BackgroundCall(CompactTaskInfo* task) {
   Log(options_.info_log, "[%s] BackgroundCall", dbname_.c_str());
   MutexLock l(&mutex_);
-  assert(bg_compaction_scheduled_);
+  assert(compact_set_.size() > 0);
   if (!shutting_down_.Acquire_Load()) {
     Status s = BackgroundCompaction();
     if (s.ok()) {
@@ -835,7 +885,7 @@ void DBImpl::BackgroundCall() {
     }
   }
 
-  bg_compaction_scheduled_ = false;
+  DeleteCompactTask(task);
 
   // Previous compaction may have produced too many files in a level,
   // so reschedule another compaction if needed.
@@ -846,7 +896,7 @@ void DBImpl::BackgroundCall() {
 Status DBImpl::BackgroundCompaction() {
   mutex_.AssertHeld();
 
-  if (imm_ != NULL) {
+  if ((imm_ != NULL) && (imm_dump_ == false)) {
     return CompactMemTable();
   }
 
@@ -867,7 +917,11 @@ Status DBImpl::BackgroundCompaction() {
         (m->end ? m->end->DebugString().c_str() : "(end)"),
         (m->done ? "(end)" : manual_end.DebugString().c_str()));
   } else {
-    c = versions_->PickCompaction();
+    if (multi_thread_compaction_) {
+      // TODO
+    } else {
+      c = versions_->PickCompaction();
+    }
   }
 
   Status status;
@@ -1053,6 +1107,21 @@ Status DBImpl::InstallCompactionResults(CompactionState* compact) {
   return versions_->LogAndApply(compact->compaction->edit(), &mutex_);
 }
 
+void DBImpl::MaybeDumpMemtableWhenCompaction(int64_t* imm_micros) {
+  if (multi_thread_compaction_) {
+    // TODO
+  } else {
+    const uint64_t imm_start = env_->NowMicros();
+    mutex_.Lock();
+    if (imm_ != NULL) {
+      CompactMemTable();
+      bg_cv_.SignalAll();  // Wakeup MakeRoomForWrite() if necessary
+    }
+    mutex_.Unlock();
+    *imm_micros += (env_->NowMicros() - imm_start);
+  }
+}
+
 Status DBImpl::DoCompactionWork(CompactionState* compact) {
   const uint64_t start_micros = env_->NowMicros();
   int64_t imm_micros = 0;  // Micros spent doing imm_ compactions
@@ -1095,14 +1164,7 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   for (; input->Valid() && !shutting_down_.Acquire_Load(); ) {
     // Prioritize immutable compaction work
     if (has_imm_.NoBarrier_Load() != NULL) {
-      const uint64_t imm_start = env_->NowMicros();
-      mutex_.Lock();
-      if (imm_ != NULL) {
-        CompactMemTable();
-        bg_cv_.SignalAll();  // Wakeup MakeRoomForWrite() if necessary
-      }
-      mutex_.Unlock();
-      imm_micros += (env_->NowMicros() - imm_start);
+      MaybeDumpMemtableWhenCompaction(&imm_micros);
     }
 
     Slice key = input->key();
@@ -1250,8 +1312,11 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
     status = InstallCompactionResults(compact);
   }
   VersionSet::LevelSummaryStorage tmp;
+  double time_used = static_cast<double>(stats.micros);
+  double compact_rate = (time_used == 0 ? 0 : compact->total_bytes/time_used);
   Log(options_.info_log,
-      "[%s] compacted to: %s", dbname_.c_str(), versions_->LevelSummary(&tmp));
+      "[%s] compacted to: %s, cost time:%ld, rate:%lf", dbname_.c_str(),
+      versions_->LevelSummary(&tmp), stats.micros, compact_rate);
   return status;
 }
 

--- a/src/leveldb/db/db_impl.h
+++ b/src/leveldb/db/db_impl.h
@@ -97,6 +97,11 @@ class DBImpl : public DB {
   struct CompactionState;
   struct Writer;
 
+  struct CompactTaskInfo {
+    int64_t id;
+    class DBImpl *db;
+  };
+
   Iterator* NewInternalIterator(const ReadOptions&,
                                 SequenceNumber* latest_snapshot);
 
@@ -122,7 +127,7 @@ class DBImpl : public DB {
 
   void MaybeScheduleCompaction() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   static void BGWork(void* db);
-  void BackgroundCall();
+  void BackgroundCall(CompactTaskInfo* task);
   Status BackgroundCompaction() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   void CleanupCompaction(CompactionState* compact)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
@@ -146,6 +151,12 @@ class DBImpl : public DB {
   uint64_t GetLastVerSequence();
   bool CheckMemTableCompaction(uint64_t last_sequence);
   MemTable* NewMemTable() const;
+  void AddCompactTask(double score);
+  void DeleteCompactTask(CompactTaskInfo* task);
+  void ReScheduleAllCompactTask(double score);
+  void WaitCompactionDone();
+  void MaybeScheduleSingleThreadCompaction();
+  void MaybeDumpMemtableWhenCompaction(int64_t* imm_micros);
 
   // Constant after construction
   Env* const env_;
@@ -192,9 +203,22 @@ class DBImpl : public DB {
   std::set<uint64_t> pending_outputs_;
 
   // Has a background compaction been scheduled or is running?
+  // multi thread compaction doesn't care this
   bool bg_compaction_scheduled_;
+
+  // multi thread compaction doesn't care this
   double bg_compaction_score_;
+
+  // multi thread compaction doesn't care this
   int64_t bg_schedule_id_;
+
+  // is immtable being dumped
+  bool imm_dump_;
+
+  // is using multi thread compaction
+  bool multi_thread_compaction_;
+
+  std::set<CompactTaskInfo*> compact_set_;
 
   // Information for a manual compaction
   struct ManualCompaction {


### PR DESCRIPTION
#98
将原来的compact逻辑适当隔离出来，本次改动和之前的代码逻辑上是一样的（如果有逻辑不一样的地方请报告bug）。
目的：使得可以通过选项控制compact执行原有逻辑还是多线程逻辑。

用一个集合set保存当前compact的任务，对于单线程compact来说，此集合最多保存一个item，对于多线程来说可能保存多个。这个set用以统一单线程、多线程逻辑。最重要的是，它会保存线程池中任务的id，方便unload时的reschedule.