### PR TITLE
issue=#363 scan-bugfix_default-rawkey-binary

### DIFF
--- a/src/sdk/scan_impl.h
+++ b/src/sdk/scan_impl.h
@@ -48,6 +48,7 @@ public:
                                   ScanTabletResponse* response) = 0;
     virtual void OnFinish(ScanTabletRequest* request,
                           ScanTabletResponse* response) = 0;
+    std::string GetNextStartPoint(const std::string& str);
 
 protected:
     tera::ScanDescImpl* _scan_desc_impl;

--- a/src/sdk/schema_impl.cc
+++ b/src/sdk/schema_impl.cc
@@ -189,7 +189,7 @@ TableDescImpl::TableDescImpl(const std::string& tb_name)
     : _name(tb_name),
       _next_lg_id(0),
       _next_cf_id(0),
-      _raw_key_type(kReadable),
+      _raw_key_type(kBinary),
       _split_size(FLAGS_tera_master_split_tablet_size),
       _merge_size(FLAGS_tera_master_merge_tablet_size),
       _disable_wal(false) {

--- a/src/sdk/table_impl.h
+++ b/src/sdk/table_impl.h
@@ -193,6 +193,7 @@ public:
 
     uint64_t GetMaxMutationPendingNum() { return _max_commit_pending_num; }
     uint64_t GetMaxReaderPendingNum() { return _max_reader_pending_num; }
+    TableSchema GetTableSchema() { return  _table_schema; }
 
     struct PerfCounter {
         int64_t start_time;


### PR DESCRIPTION
#363 

形如以下case：

"a"
"a\x0ccc"
"a\x1ccc"

如果构造某种场景使得某次scan结束的时候最后一个key为"a"，那么原逻辑"+\1"会使得case所示的第二条数据被漏掉；新逻辑修复了这个问题。