### PR TITLE
issue=#319 run-unit-test-when-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
     - ( cd protobuf-2.6.1 && ./configure --with-pic && make -j4 && sudo make install && sudo ldconfig )
 
     - git clone https://github.com/google/snappy
-    - ( cd snappy && sh ./autogen.sh && ./configure --with-pic && make -j4 && sudo make install )
+    - ( cd snappy && sh ./autogen.sh && ./configure --with-pic && make -j4 && sudo make install && sudo ldconfig )
 
     - git clone https://github.com/BaiduPS/sofa-pbrpc
     - ( cd sofa-pbrpc && make -j4 && make install )
@@ -34,7 +34,7 @@ install:
 
     - wget https://googledrive.com/host/0B6NtGsLhIcf7MWxMMF9JdTN3UVk/gperftools-2.2.1.tar.gz
     - tar zxvf gperftools-2.2.1.tar.gz
-    - ( cd gperftools-2.2.1 && ./configure --with-pic && make -j4 && sudo make install )
+    - ( cd gperftools-2.2.1 && ./configure --with-pic && make -j4 && sudo make install && sudo ldconfig )
 
     - git clone https://github.com/fxsjy/ins
     - (cd ins && PBRPC_PATH=../sofa-pbrpc/output/ make sdk )
@@ -53,3 +53,4 @@ before_script:
 
 script:
     - make -j4
+    - make check

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ PROGRAM = tera_main teracli teramo
 LIBRARY = libtera.a
 JNILIBRARY = libjni_tera.so
 BENCHMARK = tera_bench tera_mark
-TEST = prop_tree_test tprinter_test tablet_io_test
+TESTS = prop_tree_test tprinter_test
 
 .PHONY: all clean cleanall test
 
-all: $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TEST)
+all: $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TESTS)
 	mkdir -p build/include build/lib build/bin build/log build/benchmark
 	mkdir -p $(UNITTEST_OUTPUT)
-	mv $(TEST) $(UNITTEST_OUTPUT)
+	mv $(TESTS) $(UNITTEST_OUTPUT)
 	cp $(PROGRAM) build/bin
 	cp $(LIBRARY) $(JNILIBRARY) build/lib
 	cp src/leveldb/tera_bench .
@@ -78,10 +78,15 @@ all: $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TEST)
 	cp -r conf build
 	echo 'Done'
 
+check: $(TESTS)
+	( cd $(UNITTEST_OUTPUT); \
+	for t in $(TESTS); do echo "***** Running $$t"; ./$$t || exit 1; done )
+	$(MAKE) check -C src/leveldb 
+
 clean:
 	rm -rf $(ALL_OBJ) $(PROTO_OUT_CC) $(PROTO_OUT_H) $(TEST_OUTPUT)
 	$(MAKE) clean -C src/leveldb
-	rm -rf $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TEST)
+	rm -rf $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TESTS)
 
 cleanall:
 	$(MAKE) clean

--- a/src/leveldb/util/bloom_test.cc
+++ b/src/leveldb/util/bloom_test.cc
@@ -141,8 +141,8 @@ TEST(BloomTest, VaryingLengths) {
     // Check false positive rate
     double rate = FalsePositiveRate();
     if (kVerbose >= 1) {
-      fprintf(stderr, "False positives: %5.2f%% @ length = %6d ; bytes = %6d\n",
-              rate*100.0, length, static_cast<int>(FilterSize()));
+      fprintf(stderr, "False positives: %5.2f%% @ length = %6zd ; bytes = %6zd\n",
+              rate*100.0, length, FilterSize());
     }
     ASSERT_LE(rate, 0.02);   // Must not be over 2%
     if (rate > 0.0125) mediocre_filters++;  // Allowed, but not too often


### PR DESCRIPTION
将leveldb的单元测试集成到build系统中，在traivs上跑leveldb单测120s左右。

顺手将其它几个单测也拉进来了。

but，`tablet_io_test`有问题，暂时没有加入，需要另开一个story修复。