### PR TITLE
flagfile-priority-order

### DIFF
--- a/src/sdk/client_impl.cc
+++ b/src/sdk/client_impl.cc
@@ -977,9 +977,6 @@ static int SpecifiedFlagfileCount(const std::string& confpath) {
     if (!FLAGS_tera_sdk_conf_file.empty()) {
         count++;
     }
-    if (getenv("TERA_CONF")) {
-        count++;
-    }
     return count;
 }
 
@@ -1003,15 +1000,12 @@ static int InitFlags(const std::string& confpath, const std::string& log_prefix)
     } else if (!FLAGS_tera_sdk_conf_file.empty() && !IsExist(confpath)) {
         LOG(ERROR) << "specified config file(FLAGS_tera_sdk_conf_file) not found";
         return -1;
-    } else if (IsExist(utils::GetValueFromEnv("TERA_CONF"))) {
-        flagfile += utils::GetValueFromEnv("TERA_CONF");
-    } else if (getenv("TERA_CONF")) {
-        LOG(ERROR) << "specified config file(environment variable) not found";
-        return -1;
     } else if (IsExist("./tera.flag")) {
         flagfile += "./tera.flag";
     } else if (IsExist("../conf/tera.flag")) {
         flagfile += "../conf/tera.flag";
+    } else if (IsExist(utils::GetValueFromEnv("TERA_CONF"))) {
+        flagfile += utils::GetValueFromEnv("TERA_CONF");
     } else {
         LOG(ERROR) << "hasn't specify the flagfile, but default config file not found";
         return -1;


### PR DESCRIPTION
出于兼容性考虑，将环境变量的优先级调低至和原来相同的等级。