### PR TITLE
table-name-bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHARED_CFLAGS = -fPIC
 SHARED_LDFLAGS = -shared -Wl,-soname -Wl,
 
 INCPATH += -I./src -I./include -I./src/leveldb/include -I./src/leveldb \
-		   -I./src/sdk/java/native-src $(DEPS_INCPATH) 
+		   -I./src/sdk/java/native-src $(DEPS_INCPATH)
 CFLAGS += $(OPT) $(SHARED_CFLAGS) $(INCPATH)
 CXXFLAGS += $(OPT) $(SHARED_CFLAGS) $(INCPATH)
 LDFLAGS += -rdynamic $(DEPS_LDPATH) $(DEPS_LDFLAGS) -lpthread -lrt -lz -ldl
@@ -62,7 +62,7 @@ PROGRAM = tera_main teracli teramo
 LIBRARY = libtera.a
 JNILIBRARY = libjni_tera.so
 BENCHMARK = tera_bench tera_mark
-TESTS = prop_tree_test tprinter_test
+TESTS = prop_tree_test tprinter_test string_util_test
 
 .PHONY: all clean cleanall test
 
@@ -81,7 +81,7 @@ all: $(PROGRAM) $(LIBRARY) $(JNILIBRARY) $(BENCHMARK) $(TESTS)
 check: $(TESTS)
 	( cd $(UNITTEST_OUTPUT); \
 	for t in $(TESTS); do echo "***** Running $$t"; ./$$t || exit 1; done )
-	$(MAKE) check -C src/leveldb 
+	$(MAKE) check -C src/leveldb
 
 clean:
 	rm -rf $(ALL_OBJ) $(PROTO_OUT_CC) $(PROTO_OUT_H) $(TEST_OUTPUT)
@@ -108,9 +108,9 @@ teramo: $(MONITOR_OBJ) $(LIBRARY)
 
 tera_mark: $(MARK_OBJ) $(LIBRARY) $(LEVELDB_LIB)
 	$(CXX) -o $@ $(MARK_OBJ) $(LIBRARY) $(LEVELDB_LIB) $(LDFLAGS)
- 
-libjni_tera.so: $(JNI_TERA_OBJ) $(LIBRARY) 
-	$(CXX) -shared $(JNI_TERA_OBJ) -Xlinker "-(" $(LIBRARY) $(LDFLAGS) -Xlinker "-)" -o $@ 
+
+libjni_tera.so: $(JNI_TERA_OBJ) $(LIBRARY)
+	$(CXX) -shared $(JNI_TERA_OBJ) -Xlinker "-(" $(LIBRARY) $(LDFLAGS) -Xlinker "-)" -o $@
 
 src/leveldb/libleveldb.a: FORCE
 	$(MAKE) -C src/leveldb
@@ -119,10 +119,13 @@ tera_bench:
 
 # unit test
 prop_tree_test: src/utils/test/prop_tree_test.o $(LIBRARY)
-	$(CXX) -o $@ $^ $(LDFLAGS) 
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 tprinter_test: src/utils/test/tprinter_test.o $(LIBRARY)
-	$(CXX) -o $@ $^ $(LDFLAGS) 
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+string_util_test: src/utils/test/string_util_test.o $(LIBRARY)
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 tablet_io_test: src/io/test/tablet_io_test.o src/tabletnode/tabletnode_sysinfo.o\
 		$(IO_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LEVELDB_LIB)
@@ -139,8 +142,8 @@ FORCE:
 
 .PHONY: proto
 proto: $(PROTO_OUT_CC) $(PROTO_OUT_H)
- 
+
 %.pb.cc %.pb.h: %.proto
 	$(PROTOC) --proto_path=./src/proto/ --proto_path=$(PROTOBUF_INCDIR) \
                   --proto_path=$(SOFA_PBRPC_INCDIR) \
-                  --cpp_out=./src/proto/ $< 
+                  --cpp_out=./src/proto/ $<

--- a/doc/teracli.md
+++ b/doc/teracli.md
@@ -10,6 +10,10 @@ teracli命令行工具使用手册
 
 其中，table-schema是一个描述表格结构的字符串,语法详见[PropTree](https://github.com/BaiduPS/tera/blob/master/doc/prop_tree.md)
 
+表名规范：首字符为字母（大小写均可），
+有效字符包括大小写的英文字母(a-zA-Z)、数字(0-9)、下划线(`_`)、连字符(`-`)、点(`.`)。
+1 <= 有效长度 <= 512.
+
 Tera支持在建立表格时预分配若干tablet，tablet分隔的key写在tablet-delimiter-file中，按“\n”分隔。
 
 如果表格schema比较复杂，可以将其写入文件中，通过createbyfile命令进行创建。
@@ -17,7 +21,7 @@ Tera支持在建立表格时预分配若干tablet，tablet分隔的key写在tabl
 ### 创建表格模式存储
 
 表格结构中包含表名、locality groups定义、column families定义，一个典型的表格定义如下（可写入文件）：
-    
+
     # 二进制编码的key, tablet分裂阈值为4096M，合并阈值为512M
     # 三个lg，分别配置为内存、flash、磁盘存储
     table_hello <rawkey=binary, splitsize=4096, mergesize=512> {
@@ -32,11 +36,11 @@ Tera支持在建立表格时预分配若干tablet，tablet分隔的key写在tabl
             data <maxversions=10>
         }
     }
-    
+
 如果只希望简单的使用tera，对性能没有很高要求，那么schema只需指定表名和所需列名即可（如需要，所有的属性也是可配的）：
 
     table_hello {cf0, cf1, cf2}
-    
+
 ### 创建key-value模式存储
 
 tera支持高性能的key-value存储，其schema只需指定表名即可，若需要指定存储介质等属性，可选择性添加：
@@ -48,15 +52,15 @@ tera支持高性能的key-value存储，其schema只需指定表名即可，若�
 
 span | 属性名 | 意义 | 有效取值 | 单位 | 默认值 | 其它说明
 ---  | ---    | ---  | ---      | ---  | ---    | ---
-table | rawkey | rawkey的拼装模式 | "readable"：性能较高，但不允许包含`\0`。"binary"：性能差一些，允许所有字符。 | - | "readable" | 
-table | splitsize | 某个tablet增大到此阈值时分裂为2个子tablets| >=0，等于0时关闭split | MB | 512 | 
+table | rawkey | rawkey的拼装模式 | "binary"：允许所有字符。 | - | "binary" |
+table | splitsize | 某个tablet增大到此阈值时分裂为2个子tablets| >=0，等于0时关闭split | MB | 512 |
 table | mergesize | 某个tablet减小到此阈值时和相邻的1个tablet合并 | >=0，等于0时关闭merge | MB | 0 | splitsize至少要为mergesize的5倍
-lg    | storage   | 存储类型 | "disk" / "flash" / "memory" | - | "disk" | 
-lg    | compress  | 压缩算法 | "snappy" / "none" | - | "snappy" | 
-lg    | blocksize | LevelDB中block的大小       | >0 | KB | 4 | 
-lg    | use_memtable_on_leveldb | 是否启用内存compact | "true" / "false" | - | false | 
-lg    | sst_size  | 第一层sst文件大小 | >0 | Bytes | 8,000,000 | 
-cf    | maxversions | 保存的最大版本数  | >0 | - | 1 | 
+lg    | storage   | 存储类型 | "disk" / "flash" / "memory" | - | "disk" |
+lg    | compress  | 压缩算法 | "snappy" / "none" | - | "snappy" |
+lg    | blocksize | LevelDB中block的大小       | >0 | KB | 4 |
+lg    | use_memtable_on_leveldb | 是否启用内存compact | "true" / "false" | - | false |
+lg    | sst_size  | 第一层sst文件大小 | >0 | Bytes | 8,000,000 |
+cf    | maxversions | 保存的最大版本数  | >0 | - | 1 |
 cf    | minversions | 保存的最小版本数 | >0 | - | 1 |
 cf    | ttl | 数据有效时间 | >=0，等于0时此数据永远有效 | second | 0 | 小于0表示提前过期；和minversions冲突时以minversions为准
 
@@ -82,14 +86,14 @@ cf    | diskquota   | 存储限额  | >0 | MB | 0 | 暂未使用
 #### 示例
 
 更新table级别的属性（不更新lg、cf属性）：
-    
+
 ```bash
-./teracli update "oops<mergesize=512>" 
-./teracli update "oops<splitsize=1024,mergesize=128>" 
+./teracli update "oops<mergesize=512>"
+./teracli update "oops<splitsize=1024,mergesize=128>"
 ```
 
 更新lg属性（不更新cf属性）：
-    
+
 ```bash
 ./teracli update "oops{lg0<sst_size=9>}"
 
@@ -109,7 +113,7 @@ cf    | diskquota   | 存储限额  | >0 | MB | 0 | 暂未使用
 增加、删除cf：
 
 ```bash
-# 在lg0下增加cf1，并设置属性ttl值为123. 
+# 在lg0下增加cf1，并设置属性ttl值为123.
 # op意为操作，op=add需要放在cf属性的最前面
 ./teracli update "oops{lg0{cf1<op=add,ttl=123>}}"
 

--- a/src/sdk/client_impl.cc
+++ b/src/sdk/client_impl.cc
@@ -19,6 +19,7 @@
 #include "sdk/sdk_utils.h"
 #include "sdk/sdk_zk.h"
 #include "utils/crypt.h"
+#include "utils/string_util.h"
 #include "utils/utils_cmd.h"
 
 DECLARE_string(tera_master_meta_table_name);
@@ -124,6 +125,12 @@ bool ClientImpl::CheckReturnValue(StatusCode status, std::string& reason, ErrorC
 bool ClientImpl::CreateTable(const TableDescriptor& desc,
                              const std::vector<string>& tablet_delim,
                              ErrorCode* err) {
+    if (!IsValidTableName(desc.TableName())) {
+        if (err != NULL) {
+            err->SetFailed(ErrorCode::kBadParam, " invalid tablename ");
+        }
+        return false;
+    }
     master::MasterClient master_client(_cluster->MasterAddr());
 
     CreateTableRequest request;
@@ -806,7 +813,7 @@ bool ClientImpl::DelSnapshot(const string& name, uint64_t snapshot, ErrorCode* e
     return false;
 }
 
-bool ClientImpl::Rollback(const string& name, uint64_t snapshot, 
+bool ClientImpl::Rollback(const string& name, uint64_t snapshot,
                           const std::string& rollback_name, ErrorCode* err) {
     master::MasterClient master_client(_cluster->MasterAddr());
 

--- a/src/utils/string_util.cc
+++ b/src/utils/string_util.cc
@@ -6,6 +6,8 @@
 
 #include <stdint.h>
 
+namespace tera {
+
 bool IsVisible(char c) {
     return (c >= 0x20 && c <= 0x7E);
 }
@@ -40,3 +42,29 @@ std::string DebugString(const std::string& src) {
 
     return dst.substr(0, j);
 }
+
+bool IsValidTableName(const std::string& str) {
+    return IsValidName(str);
+}
+
+const size_t kNameLenMin = 1;
+const size_t kNameLenMax = 512;
+
+bool IsValidName(const std::string& str) {
+    if (str.size() < kNameLenMin || kNameLenMax < str.size()) {
+        return false;
+    }
+    if (!(isupper(str[0]) || islower(str[0]))) {
+        return false;
+    }
+    for (size_t i = 0; i < str.size(); ++i) {
+        char c = str[i];
+        if (!(isdigit(c) || isupper(c) || islower(c)
+              || (c == '_') || (c == '.') || (c == '-'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace tera

--- a/src/utils/string_util.h
+++ b/src/utils/string_util.h
@@ -7,6 +7,15 @@
 
 #include <string>
 
-std::string DebugString(const std::string& src);
+namespace tera {
+
+    extern const size_t kNameLenMin;
+    extern const size_t kNameLenMax;
+
+    std::string DebugString(const std::string& src);
+    bool IsValidName(const std::string& str);
+    bool IsValidTableName(const std::string& str);
+
+} // namespace tera
 
 #endif  // TERA_UTIL_STRING_UTIL_H_

--- a/src/utils/test/string_util_test.cc
+++ b/src/utils/test/string_util_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "utils/string_util.h"
+
+#include <gtest/gtest.h>
+
+namespace tera {
+
+TEST(StringUtilTest, IsValidName) {
+    ASSERT_FALSE(IsValidName(""));
+    ASSERT_FALSE(IsValidName(std::string("\0", 1)));
+    ASSERT_FALSE(IsValidName("\1"));
+
+    ASSERT_FALSE(IsValidName(std::string(kNameLenMin - 1, 'a')));
+    ASSERT_TRUE(IsValidName(std::string(kNameLenMin, 'a')));
+    ASSERT_TRUE(IsValidName(std::string(kNameLenMin + 1, 'a')));
+
+    ASSERT_TRUE(IsValidName(std::string(kNameLenMax - 1, 'a')));
+    ASSERT_TRUE(IsValidName(std::string(kNameLenMax, 'a')));
+    ASSERT_FALSE(IsValidName(std::string(kNameLenMax + 1, 'a')));
+
+    ASSERT_FALSE(IsValidName("1abc"));
+    ASSERT_FALSE(IsValidName("_1abc"));
+
+    ASSERT_TRUE(IsValidName("a"));
+    ASSERT_TRUE(IsValidName("A"));
+    ASSERT_TRUE(IsValidName("abcDEFGz123_233000_"));
+
+    ASSERT_FALSE(IsValidName("abcDEFGz123_233\1bac"));
+    ASSERT_FALSE(IsValidName("a~`!@#$%^&*()_=+"));
+    ASSERT_FALSE(IsValidName("a[{;:'\",<>/?\"'}]"));
+}
+
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
#416 
先yy了一个有效的表名规范：

```
表名规范：首字符为字母（大小写均可），
有效字符包括大小写的英文字母(a-zA-Z)、数字(0-9)、下划线(`_`)、连字符(`-`)、点(`.`)。
1 <= 有效长度 <= 512.
```

求吐槽，求建议。


有2个问题（求观点，求分享）：

1. 检查表名的位置：目前是在sdk实现的。不考虑恶意攻击，在sdk检查是ok的。

  方案一：在sdk检查，如本次diff所示，非常简单明了（含错误处理6行代码）。
  方案二：在master检查，但master拿到的表名可能带@符号（分割时间戳），形如`tablename + @ + timestamp`，所以不能简单地拒绝带@符号的tablename；需要parse这个tablename，先确保只包含一个@符号，再确定其第一部分为合法tablename，第二部分为@符号，最后一部分为合法的timestamp，略复杂。

  所以我选择了方案一（简单可行）。

2. 在`string_util.cc`中，将 tablename 长度的最小值、最大值作为了全局常量，主要是为了便于在单测中构造测试用例（单测可以直接从被测代码中获取这2个阈值）。不然在代码和单测中各自维护一套最小值、最大值，一致性很难保证，不排除未来改动会导致潜在的风险。