### PR TITLE
issue=#437 tableschema-on-zk

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -547,6 +547,7 @@ bool MasterImpl::LoadMetaTable(const std::string& meta_tablet_addr,
             } else if (first_key_char == '@') {
                 m_tablet_manager->LoadTableMeta(record.key(), record.value());
                 FillAlias(record.key(), record.value());
+                PutTableSchemaToZk(record.key(), record.value());
             } else if (first_key_char > '@') {
                 m_tablet_manager->LoadTabletMeta(record.key(), record.value());
             } else {
@@ -563,6 +564,23 @@ bool MasterImpl::LoadMetaTable(const std::string& meta_tablet_addr,
     LOG(ERROR) << "fail to load meta table: " << StatusCodeToString(kRPCError);
     m_tablet_manager->ClearTableList();
     return false;
+}
+
+void MasterImpl::PutTableSchemaToZk(const std::string& key, const std::string& value) {
+    TableMeta meta;
+    ParseMetaTableKeyValue(key, value, &meta);
+    WriteTableNode(meta.schema());
+}
+
+void MasterImpl::WriteTableNode(const TableSchema& schema) {
+    if ((schema.admin() == "") && (schema.admin_group().size() == 0)) {
+        return;
+    }
+    std::string schema_str;
+    schema.SerializeToString(&schema_str);
+    if (!m_zk_adapter->WriteTableNode(schema.name(), schema_str)) {
+        LOG(ERROR) << "[acl] write node:" << schema.name() << " failed";
+    }
 }
 
 void MasterImpl::FillAlias(const std::string& key, const std::string& value) {
@@ -4174,6 +4192,8 @@ void MasterImpl::AddMetaCallback(TablePtr table,
         return;
     }
 
+    WriteTableNode(table->GetSchema());
+
     rpc_response->set_status(kMasterOk);
     rpc_done->Run();
     LOG(INFO) << "create table " << tablets[0]->GetTableName() << " success";
@@ -4302,6 +4322,9 @@ void MasterImpl::UpdateTableRecordForUpdateCallback(TablePtr table, int32_t retr
         }
         return;
     }
+
+    WriteTableNode(table->GetSchema());
+
     LOG(INFO) << "update meta table success, " << table;
     rpc_response->set_status(kMasterOk);
     rpc_done->Run();
@@ -4503,6 +4526,11 @@ void MasterImpl::DeleteTableCallback(TablePtr table,
         m_tablet_manager->DeleteTablet(tablet->GetTableName(), tablet->GetKeyStart());
     }
     LOG(INFO) << "delete meta table record success, " << table;
+
+    if (!m_zk_adapter->DeleteTableNode(table->GetTableName())) {
+        LOG(ERROR) << "[acl] delete node:" << table->GetTableName() << " failed";
+    }
+
     rpc_response->set_status(kMasterOk);
     rpc_done->Run();
 }

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -526,6 +526,8 @@ private:
                                Callback* done, TablePtr table, const char* operate);
 
     void FillAlias(const std::string& key, const std::string& value);
+    void WriteTableNode(const TableSchema& schema);
+    void PutTableSchemaToZk(const std::string& key, const std::string& value);
 private:
     mutable Mutex m_status_mutex;
     MasterStatus m_status;

--- a/src/master/master_zk_adapter.h
+++ b/src/master/master_zk_adapter.h
@@ -34,6 +34,9 @@ public:
     virtual bool MarkSafeMode() = 0;
     virtual bool UnmarkSafeMode() = 0;
     virtual bool UpdateRootTabletNode(const std::string& root_tablet_addr) = 0;
+    virtual bool WriteTableNode(const std::string& table_name,
+                                const std::string& table_schema) = 0;
+    virtual bool DeleteTableNode(const std::string& table_name) = 0;
 };
 
 class MasterZkAdapter : public MasterZkAdapterBase {
@@ -50,6 +53,9 @@ public:
     virtual bool MarkSafeMode();
     virtual bool UnmarkSafeMode();
     virtual bool UpdateRootTabletNode(const std::string& root_tablet_addr);
+    virtual bool WriteTableNode(const std::string& table_name,
+                                const std::string& table_schema);
+    virtual bool DeleteTableNode(const std::string& table_name);
 
 protected:
     bool Setup();
@@ -86,6 +92,14 @@ protected:
                                int err);
     virtual void OnSessionTimeout();
 
+    virtual bool WriteNodeWithRetry(const std::string& path,
+                                    const std::string& value);
+    virtual bool CheckExistWithRetry(const std::string& zk_path);
+    virtual bool CreateIfNotExistWithRetry(const std::string& path,
+                                       const std::string& value);
+    virtual bool UpdatePersistentNodeWithCreate(const std::string& zk_path,
+                                                const std::string& value);
+    virtual bool DeleteNodeWithRetry(const std::string& path);
 private:
     mutable Mutex m_mutex;
     MasterImpl * m_master_impl;
@@ -112,7 +126,9 @@ public:
     virtual bool MarkSafeMode();
     virtual bool UnmarkSafeMode();
     virtual bool UpdateRootTabletNode(const std::string& root_tablet_addr);
-
+    virtual bool WriteTableNode(const std::string& table_name,
+                                const std::string& table_schema);
+    virtual bool DeleteTableNode(const std::string& table_name);
 private:
     virtual void OnChildrenChanged(const std::string& path,
                                    const std::vector<std::string>& name_list,
@@ -147,6 +163,9 @@ public:
     virtual bool MarkSafeMode() {return true;}
     virtual bool UnmarkSafeMode() {return true;}
     virtual bool UpdateRootTabletNode(const std::string& root_tablet_addr);
+    virtual bool WriteTableNode(const std::string& table_name,
+                                const std::string& table_schema);
+    virtual bool DeleteTableNode(const std::string& table_name);
     void RefreshTabletNodeList();
     void OnLockChange(std::string session_id, bool deleted);
     void OnSessionTimeout();

--- a/src/tabletnode/tabletnode_impl.cc
+++ b/src/tabletnode/tabletnode_impl.cc
@@ -291,6 +291,16 @@ void TabletNodeImpl::LoadTablet(const LoadTabletRequest* request,
         response->set_status(kTabletNodeOk);
     }
 
+    if ((schema.admin() != "") || (schema.admin_group().size() != 0)) {
+        bool is_exist;
+        int zk_errno;
+        if (m_zk_adapter->WatchTableNode(request->tablet_name(), &is_exist, &zk_errno)) {
+            LOG(INFO) << "[acl] watch success:" << request->tablet_name();
+        } else {
+            LOG(ERROR) << "[acl] zk_errno:" << zk::ZkErrnoToString(zk_errno);
+        }
+    }
+
     LOG(INFO) << "load tablet: " << request->path() << " ["
         << DebugString(key_start) << ", " << DebugString(key_end) << "]";
     done->Run();
@@ -328,6 +338,8 @@ bool TabletNodeImpl::UnloadTablet(const std::string& tablet_name,
             << "], status: " << StatusCodeToString(*status);
     }
     *status = kTabletNodeOk;
+
+    // TODO(taocipian) delete table node watch
     return true;
 }
 

--- a/src/tabletnode/tabletnode_zk_adapter.h
+++ b/src/tabletnode/tabletnode_zk_adapter.h
@@ -27,6 +27,8 @@ public:
     virtual ~TabletNodeZkAdapterBase() {};
     virtual void Init() = 0;
     virtual bool GetRootTableAddr(std::string* root_table_addr) = 0;
+    virtual bool WatchTableNode(const std::string& path,
+                                bool* is_exist, int* zk_errno) = 0;
 };
 
 class TabletNodeZkAdapter : public TabletNodeZkAdapterBase {
@@ -36,6 +38,8 @@ public:
     virtual ~TabletNodeZkAdapter();
     virtual void Init();
     virtual bool GetRootTableAddr(std::string* root_table_addr);
+    virtual bool WatchTableNode(const std::string& path,
+                                bool* is_exist, int* zk_errno);
 
 private:
     bool Register(const std::string& session_id, int* zk_code);
@@ -55,6 +59,8 @@ private:
     void OnRootNodeDeleted();
     void OnRootNodeChanged(const std::string& root_tablet_addr);
 
+    void OnTableNodeChanged(const std::string& path,
+                            const std::string& value);
     virtual void OnChildrenChanged(const std::string& path,
                                    const std::vector<std::string>& name_list,
                                    const std::vector<std::string>& data_list);
@@ -79,6 +85,8 @@ public:
     virtual ~FakeTabletNodeZkAdapter() {}
     virtual void Init();
     virtual bool GetRootTableAddr(std::string* root_table_addr);
+    virtual bool WatchTableNode(const std::string& path,
+                                bool* is_exist, int* zk_errno);
 
 private:
     bool Register(const std::string& session_id, int* zk_code = NULL);
@@ -109,9 +117,13 @@ public:
     virtual ~InsTabletNodeZkAdapter() {}
     virtual void Init();
     virtual bool GetRootTableAddr(std::string* root_table_addr);
+    virtual bool WatchTableNode(const std::string& path,
+                                bool* is_exist, int* zk_errno);
     void OnKickMarkCreated();
     void OnLockChange(std::string session_id, bool deleted);
     void OnMetaChange(std::string meta_addr, bool deleted);
+    void OnTableChange(const std::string& path, bool deleted);
+
 private:
     virtual void OnChildrenChanged(const std::string& path,
                                    const std::vector<std::string>& name_list,
@@ -122,7 +134,6 @@ private:
     virtual void OnNodeDeleted(const std::string& path) {}
     virtual void OnWatchFailed(const std::string& path, int watch_type, int err) {}
     virtual void OnSessionTimeout() {}
-
 private:
     mutable Mutex m_mutex;
     TabletNodeImpl * m_tabletnode_impl;

--- a/src/types.h
+++ b/src/types.h
@@ -27,6 +27,7 @@ const std::string kTsListPath = "/ts";
 const std::string kKickPath = "/kick";
 const std::string kRootTabletNodePath = "/root_table";
 const std::string kSafeModeNodePath = "/safemode";
+const std::string kTablePath = "/table";
 const std::string kSms = "[SMS] ";
 const std::string kMail = "[MAIL] ";
 const int64_t kLatestTs = INT64_MAX;


### PR DESCRIPTION
#437 

本次pr实现：
master把table的schema写到分布式协调服务上；建一个和ts、kick同级的table目录，一个表格在其下有一个子结点。
ts执行watch
（本次pr中ts收到watch通知只是打个日志，没有其它逻辑）。

为保证数据和meta表一致，master初始化时把table的schema统一写入分布式协调服务；
建表、更新schema时在写完meta表之后写zk；写失败打log.
删表时删除对应结点。

在zk和nexus上测试。