### PR TITLE
table-owner

### DIFF
--- a/src/master/user_manager.cc
+++ b/src/master/user_manager.cc
@@ -4,7 +4,8 @@
 
 #include "user_manager.h"
 
-#include <glog/logging.h>
+#include "glog/logging.h"
+#include "utils/string_util.h"
 
 namespace tera {
 namespace master {
@@ -127,25 +128,10 @@ void UserManager::SetupRootUser() {
     LOG(INFO) << "[user-manager] root restored";
 }
 
-bool UserManager::IsUserNameValid(const std::string& user_name) {
-    const size_t kLenMin = 2;
-    const size_t kLenMax = 32;
-    if (user_name.length() < kLenMin || kLenMax < user_name.length()
-        || !isalpha(user_name[0])) {
-        return false;
-    }
-    for (size_t i = 0; i < user_name.length(); ++i) {
-        if (!isalnum(user_name[i]) && (user_name[i] != '_')) {
-            return false;
-        }
-    }
-    return true;
-}
-
 bool UserManager::IsValidForCreate(const std::string& token,
                                    const std::string& user_name) {
     LOG(INFO) << "[user-manager] " << user_name << ", " << token;
-    return IsUserNameValid(user_name)
+    return IsValidUserName(user_name)
            && !IsUserExist(user_name)
            && TokenToUserName(token) == "root";
 }

--- a/src/sdk/client_impl.cc
+++ b/src/sdk/client_impl.cc
@@ -146,7 +146,6 @@ bool ClientImpl::CreateTable(const TableDescriptor& desc,
     TableDescToSchema(desc, schema);
     schema->set_alias(desc.TableName());
     schema->set_name(internal_table_name);
-    schema->set_admin(_user_identity);
     // add delimiter
     size_t delim_num = tablet_delim.size();
     for (size_t i = 0; i < delim_num; ++i) {

--- a/src/sdk/schema.cc
+++ b/src/sdk/schema.cc
@@ -135,8 +135,16 @@ void TableDescriptor::SetAdminGroup(const std::string& name) {
     return _impl->SetAdminGroup(name);
 }
 
+void TableDescriptor::SetAdmin(const std::string& name) {
+    return _impl->SetAdmin(name);
+}
+
 std::string TableDescriptor::AdminGroup() const {
     return _impl->AdminGroup();
+}
+
+std::string TableDescriptor::Admin() const {
+    return _impl->Admin();
 }
 
 void TableDescriptor::SetAlias(const std::string& alias) {

--- a/src/sdk/schema_impl.cc
+++ b/src/sdk/schema_impl.cc
@@ -247,6 +247,14 @@ std::string TableDescImpl::AdminGroup() const {
     return _admin_group;
 }
 
+void TableDescImpl::SetAdmin(const std::string& name) {
+    _admin = name;
+}
+
+std::string TableDescImpl::Admin() const {
+    return _admin;
+}
+
 void TableDescImpl::SetAlias(const std::string& alias) {
     _alias =  alias;
 }

--- a/src/sdk/schema_impl.h
+++ b/src/sdk/schema_impl.h
@@ -182,6 +182,9 @@ public:
     void SetAdminGroup(const std::string& name);
     std::string AdminGroup() const;
 
+    void SetAdmin(const std::string& name);
+    std::string Admin() const;
+
     void SetAlias(const std::string& alias);
     std::string Alias() const;
 
@@ -204,6 +207,7 @@ private:
     int64_t         _merge_size;
     bool            _disable_wal;
     std::string     _admin_group;
+    std::string     _admin;
     std::string     _alias;
 };
 

--- a/src/sdk/tera.h
+++ b/src/sdk/tera.h
@@ -202,6 +202,9 @@ public:
     void SetAdminGroup(const std::string& name);
     std::string AdminGroup() const;
 
+    void SetAdmin(const std::string& name);
+    std::string Admin() const;
+
     /// alias
     void SetAlias(const std::string& alias);
     std::string Alias() const;

--- a/src/utils/string_util.cc
+++ b/src/utils/string_util.cc
@@ -47,6 +47,14 @@ bool IsValidTableName(const std::string& str) {
     return IsValidName(str);
 }
 
+bool IsValidGroupName(const std::string& str) {
+    return IsValidName(str);
+}
+
+bool IsValidUserName(const std::string& str) {
+    return IsValidName(str);
+}
+
 const size_t kNameLenMin = 1;
 const size_t kNameLenMax = 512;
 

--- a/src/utils/string_util.h
+++ b/src/utils/string_util.h
@@ -15,6 +15,8 @@ namespace tera {
     std::string DebugString(const std::string& src);
     bool IsValidName(const std::string& str);
     bool IsValidTableName(const std::string& str);
+    bool IsValidGroupName(const std::string& name);
+    bool IsValidUserName(const std::string& name);
 
 } // namespace tera
 


### PR DESCRIPTION
取消建表时自动带上user token的行为。
主要是基于兼容性考虑：用新teracli建出的表带上user信息以后，用旧的teracli就看不到了，会带来一定困扰。

新逻辑和最早的逻辑保持一致，不带任何权限信息；此时这个表是可以被任何人访问的，除非显示指定admin.