### PR TITLE
issue=#436 wal-log-info

### DIFF
--- a/src/leveldb/db/db_table.cc
+++ b/src/leveldb/db/db_table.cc
@@ -413,8 +413,9 @@ Status DBTable::Write(const WriteOptions& options, WriteBatch* my_batch) {
             log_->AddRecord(slice);
             s = log_->WaitDone(wait_sec);
             if (s.IsTimeOut()) {
-                Log(options_.info_log, "[%s] AddRecord time out %lu",
-                    dbname_.c_str(), current_log_size_);
+                Log(options_.info_log, "[%s] AddRecord time out, current log size: %lu, "
+                    "record size: %lu, wait_sec: %u",
+                    dbname_.c_str(), current_log_size_, slice.size(), wait_sec);
                 int ret = SwitchLog(true);
                 if (ret == 0) {
                     continue;


### PR DESCRIPTION
当时频繁出现写log超时，然后不停切，切出很多大小为0的log.
这里打点日志，信息更详细一点。

#436 