### PR TITLE
issue=#437 util-fragment-is-cover-range

### DIFF
--- a/src/utils/fragment.cc
+++ b/src/utils/fragment.cc
@@ -22,6 +22,23 @@ static int CompareTwoEndKey(const std::string& a, const std::string& b) {
     return a.compare(b);
 }
 
+bool RangeFragment::IsCoverRange(const std::string& start, const std::string& end) const {
+    std::list<std::pair<std::string, std::string> >::const_iterator it=range_.begin();
+    for ( ; it != range_.end(); ++it ) {
+        if (it->second != ""
+            && start.compare(it->second) > 0) {
+            continue;
+        }
+        break;
+    }
+
+    if (it == range_.end()) {
+        return false;
+    }
+    return (start.compare(it->first) >= 0)
+            && (CompareTwoEndKey(end, it->second) <= 0);
+}
+
 bool RangeFragment::AddToRange(const std::string& start, const std::string& end) {
     if (end != "" && start.compare(end) > 0) {
         return false;

--- a/src/utils/fragment.h
+++ b/src/utils/fragment.h
@@ -18,6 +18,8 @@ public:
 
     bool IsCompleteRange() const;
 
+    bool IsCoverRange(const std::string& start, const std::string& end) const;
+
     std::string DebugString() const;
 
 private:

--- a/src/utils/test/fragment_test.cc
+++ b/src/utils/test/fragment_test.cc
@@ -304,6 +304,85 @@ TEST(FragmentTest, Endkey) {
     ASSERT_TRUE(all.IsCompleteRange());
 }
 
+TEST(CoverTest, CompleteRange) {
+    RangeFragment all;
+    all.AddToRange("", "");
+    ASSERT_TRUE(all.IsCoverRange("", ""));
+    ASSERT_TRUE(all.IsCoverRange("", "a"));
+    ASSERT_TRUE(all.IsCoverRange("a", ""));
+    ASSERT_TRUE(all.IsCoverRange("a", "b"));
+}
+
+TEST(CoverTest, Start) {
+//  a b c d e f g h i j k l m n o p q r s t u v w x y z
+//                *
+    RangeFragment all;
+    all.AddToRange("", "h");
+
+    ASSERT_TRUE(all.IsCoverRange("", "g"));
+    ASSERT_TRUE(all.IsCoverRange("", "h"));
+    ASSERT_FALSE(all.IsCoverRange("", "i"));
+    ASSERT_FALSE(all.IsCoverRange("", ""));
+
+    ASSERT_TRUE(all.IsCoverRange("a", "g"));
+    ASSERT_TRUE(all.IsCoverRange("a", "h"));
+    ASSERT_FALSE(all.IsCoverRange("a", "i"));
+    ASSERT_FALSE(all.IsCoverRange("a", ""));
+
+    ASSERT_FALSE(all.IsCoverRange("h", "i"));
+    ASSERT_FALSE(all.IsCoverRange("h", ""));
+}
+
+TEST(CoverTest, End) {
+//  a b c d e f g h i j k l m n o p q r s t u v w x y z
+//                *
+    RangeFragment all;
+    all.AddToRange("h", "");
+    ASSERT_FALSE(all.IsCoverRange("", "g"));
+    ASSERT_FALSE(all.IsCoverRange("", "h"));
+    ASSERT_FALSE(all.IsCoverRange("", "i"));
+    ASSERT_FALSE(all.IsCoverRange("", ""));
+
+    ASSERT_FALSE(all.IsCoverRange("a", "g"));
+    ASSERT_FALSE(all.IsCoverRange("a", "h"));
+    ASSERT_FALSE(all.IsCoverRange("a", "i"));
+    ASSERT_FALSE(all.IsCoverRange("a", ""));
+
+    ASSERT_TRUE(all.IsCoverRange("h", "i"));
+    ASSERT_TRUE(all.IsCoverRange("h", ""));
+}
+
+TEST(CoverTest, Common) {
+//  a b c d e f g h i j k l m n o p q r s t u v w x y z
+//                *             *
+    RangeFragment all;
+    all.AddToRange("h", "o");
+
+    ASSERT_FALSE(all.IsCoverRange("a", "g"));
+    ASSERT_FALSE(all.IsCoverRange("a", "h"));
+    ASSERT_FALSE(all.IsCoverRange("a", "i"));
+    ASSERT_FALSE(all.IsCoverRange("a", "n"));
+    ASSERT_FALSE(all.IsCoverRange("a", "o"));
+    ASSERT_FALSE(all.IsCoverRange("a", "p"));
+    ASSERT_FALSE(all.IsCoverRange("a", ""));
+
+    ASSERT_TRUE(all.IsCoverRange("h", "i"));
+    ASSERT_TRUE(all.IsCoverRange("h", "o"));
+    ASSERT_FALSE(all.IsCoverRange("h", "p"));
+    ASSERT_FALSE(all.IsCoverRange("h", ""));
+
+    ASSERT_TRUE(all.IsCoverRange("i", "n"));
+    ASSERT_TRUE(all.IsCoverRange("i", "o"));
+    ASSERT_FALSE(all.IsCoverRange("i", "p"));
+    ASSERT_FALSE(all.IsCoverRange("i", ""));
+
+    ASSERT_FALSE(all.IsCoverRange("o", "p"));
+    ASSERT_FALSE(all.IsCoverRange("o", ""));
+
+    ASSERT_FALSE(all.IsCoverRange("p", "q"));
+    ASSERT_FALSE(all.IsCoverRange("p", ""));
+}
+
 } // namespace tera
 
 


### PR DESCRIPTION
使得这个小工具支持：任意给定一个range(start, end)，可以判断是否cover了这个range.
（其它地方要用到这个接口）

util-fragment 记录了很多range，例如
```
a b c d e f g h i j k l m n o p q r s t u v w x y z
--------e           k-------o         t-u
```
此时，util-fragment 记录的range有 ""(start无穷小) ~ e 和 k ~ o 以及 t ~ u.
那么显然，对于range(a ~ c)在这个 util-fragment 的cover中；而 range(g ~ h) 则没有被cover.