### PR TITLE
issue=#437 online-schema-change-sdk-check

### DIFF
--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -103,6 +103,10 @@ public:
                      UpdateTableResponse* response,
                      google::protobuf::Closure* done);
 
+    void UpdateCheck(const UpdateCheckRequest* request,
+                     UpdateCheckResponse* response,
+                     google::protobuf::Closure* done);
+
     void CompactTable(const CompactTableRequest* request,
                       CompactTableResponse* response,
                       google::protobuf::Closure* done);

--- a/src/master/remote_master.cc
+++ b/src/master/remote_master.cc
@@ -106,6 +106,16 @@ void RemoteMaster::UpdateTable(google::protobuf::RpcController* controller,
     m_thread_pool->AddTask(callback);
 }
 
+void RemoteMaster::UpdateCheck(google::protobuf::RpcController* controller,
+                               const UpdateCheckRequest* request,
+                               UpdateCheckResponse* response,
+                               google::protobuf::Closure* done) {
+    ThreadPool::Task callback =
+        boost::bind(&RemoteMaster::DoUpdateCheck, this, controller,
+                    request, response, done);
+    m_thread_pool->AddTask(callback);
+}
+
 void RemoteMaster::CompactTable(google::protobuf::RpcController* controller,
                                 const CompactTableRequest* request,
                                 CompactTableResponse* response,
@@ -238,6 +248,15 @@ void RemoteMaster::DoUpdateTable(google::protobuf::RpcController* controller,
     LOG(INFO) << "accept RPC (UpdateTable)";
     m_master_impl->UpdateTable(request, response, done);
     LOG(INFO) << "finish RPC (UpdateTable)";
+}
+
+void RemoteMaster::DoUpdateCheck(google::protobuf::RpcController* controller,
+                                 const UpdateCheckRequest* request,
+                                 UpdateCheckResponse* response,
+                                 google::protobuf::Closure* done) {
+    LOG(INFO) << "accept RPC (UpdateCheck)";
+    m_master_impl->UpdateCheck(request, response, done);
+    LOG(INFO) << "finish RPC (UpdateCheck)";
 }
 
 void RemoteMaster::DoCompactTable(google::protobuf::RpcController* controller,

--- a/src/master/remote_master.h
+++ b/src/master/remote_master.h
@@ -60,6 +60,11 @@ public:
                      UpdateTableResponse* response,
                      google::protobuf::Closure* done);
 
+    void UpdateCheck(google::protobuf::RpcController* controller,
+                     const UpdateCheckRequest* request,
+                     UpdateCheckResponse* response,
+                     google::protobuf::Closure* done);
+
     void CompactTable(google::protobuf::RpcController* controller,
                       const CompactTableRequest* request,
                       CompactTableResponse* response,
@@ -131,6 +136,11 @@ private:
     void DoUpdateTable(google::protobuf::RpcController* controller,
                        const UpdateTableRequest* request,
                        UpdateTableResponse* response,
+                       google::protobuf::Closure* done);
+
+    void DoUpdateCheck(google::protobuf::RpcController* controller,
+                       const UpdateCheckRequest* request,
+                       UpdateCheckResponse* response,
                        google::protobuf::Closure* done);
 
     void DoCompactTable(google::protobuf::RpcController* controller,

--- a/src/proto/master_client.cc
+++ b/src/proto/master_client.cc
@@ -87,6 +87,14 @@ bool MasterClient::UpdateTable(const UpdateTableRequest* request,
                                 "UpdateTable", m_rpc_timeout);
 }
 
+bool MasterClient::UpdateCheck(const UpdateCheckRequest* request,
+                               UpdateCheckResponse* response) {
+    return SendMessageWithRetry(&MasterServer::Stub::UpdateCheck,
+                                request, response,
+                                (Closure<void, UpdateCheckRequest*, UpdateCheckResponse*, bool, int>*)NULL,
+                                "UpdateCheck", m_rpc_timeout);
+}
+
 bool MasterClient::SearchTable(const SearchTableRequest* request,
                                SearchTableResponse* response) {
     return SendMessageWithRetry(&MasterServer::Stub::SearchTable,

--- a/src/proto/master_client.h
+++ b/src/proto/master_client.h
@@ -47,6 +47,9 @@ public:
     virtual bool UpdateTable(const UpdateTableRequest* request,
                              UpdateTableResponse* response);
 
+    virtual bool UpdateCheck(const UpdateCheckRequest* request,
+                             UpdateCheckResponse* response);
+
     virtual bool SearchTable(const SearchTableRequest* request,
                              SearchTableResponse* response);
 

--- a/src/proto/master_rpc.proto
+++ b/src/proto/master_rpc.proto
@@ -67,6 +67,18 @@ message UpdateTableResponse {
     required uint64 sequence_id = 2;
 }
 
+message UpdateCheckRequest {
+    optional uint64 sequence_id = 1;
+    optional string table_name = 2;
+    optional bytes user_token = 3;
+}
+
+message UpdateCheckResponse {
+    optional uint64 sequence_id = 1;
+    optional StatusCode status = 2;
+    optional bool done = 3;
+}
+
 message CompactTableRequest {
     required uint64 sequence_id = 1;
 }
@@ -248,6 +260,7 @@ service MasterServer {
     rpc DisableTable(DisableTableRequest) returns (DisableTableResponse);
     rpc EnableTable(EnableTableRequest) returns (EnableTableResponse);
     rpc UpdateTable(UpdateTableRequest) returns (UpdateTableResponse);
+    rpc UpdateCheck(UpdateCheckRequest) returns (UpdateCheckResponse);
     rpc CompactTable(CompactTableRequest) returns (CompactTableResponse);
     rpc SearchTable(SearchTableRequest) returns(SearchTableResponse);
 

--- a/src/sdk/client_impl.cc
+++ b/src/sdk/client_impl.cc
@@ -201,7 +201,29 @@ bool ClientImpl::UpdateTable(const TableDescriptor& desc, ErrorCode* err) {
     return false;
 }
 
-bool ClientImpl::DeleteTable(string name, ErrorCode* err) {
+bool ClientImpl::UpdateCheck(const std::string& table_name, bool* done, ErrorCode* err) {
+    master::MasterClient master_client(_cluster->MasterAddr());
+    UpdateCheckRequest request;
+    UpdateCheckResponse response;
+    request.set_sequence_id(0);
+    request.set_table_name(table_name);
+    request.set_user_token(GetUserToken(_user_identity, _user_passcode));
+
+    string reason;
+    if (master_client.UpdateCheck(&request, &response)) {
+        if (CheckReturnValue(response.status(), reason, err)) {
+            *done = response.done();
+            return true;
+        }
+        err->SetFailed(ErrorCode::kSystem, reason);
+    } else {
+        reason = "rpc fail to update-check table:" + table_name;
+        err->SetFailed(ErrorCode::kSystem, reason);
+    }
+    return false;
+}
+
+bool ClientImpl::DeleteTable(const std::string& name, ErrorCode* err) {
     std::string internal_table_name;
     if (!GetInternalTableName(name, err, &internal_table_name)) {
         LOG(ERROR) << "faild to scan meta schema";
@@ -228,7 +250,7 @@ bool ClientImpl::DeleteTable(string name, ErrorCode* err) {
     return false;
 }
 
-bool ClientImpl::DisableTable(string name, ErrorCode* err) {
+bool ClientImpl::DisableTable(const std::string& name, ErrorCode* err) {
     std::string internal_table_name;
     if (!GetInternalTableName(name, err, &internal_table_name)) {
         LOG(ERROR) << "faild to scan meta schema";
@@ -256,7 +278,7 @@ bool ClientImpl::DisableTable(string name, ErrorCode* err) {
     return false;
 }
 
-bool ClientImpl::EnableTable(string name, ErrorCode* err) {
+bool ClientImpl::EnableTable(const std::string& name, ErrorCode* err) {
     master::MasterClient master_client(_cluster->MasterAddr());
     std::string internal_table_name;
     if (!GetInternalTableName(name, err, &internal_table_name)) {

--- a/src/sdk/client_impl.h
+++ b/src/sdk/client_impl.h
@@ -42,12 +42,13 @@ public:
                              ErrorCode* err);
 
     virtual bool UpdateTable(const TableDescriptor& desc, ErrorCode* err);
+    virtual bool UpdateCheck(const std::string& table_name, bool* done, ErrorCode* err);
 
-    virtual bool DeleteTable(string name, ErrorCode* err);
+    virtual bool DeleteTable(const std::string& name, ErrorCode* err);
 
-    virtual bool DisableTable(string name, ErrorCode* err);
+    virtual bool DisableTable(const std::string& name, ErrorCode* err);
 
-    virtual bool EnableTable(string name, ErrorCode* err);
+    virtual bool EnableTable(const std::string& name, ErrorCode* err);
 
     virtual bool CreateUser(const std::string& user,
                             const std::string& password, ErrorCode* err);

--- a/src/sdk/tera.h
+++ b/src/sdk/tera.h
@@ -632,12 +632,13 @@ public:
                              ErrorCode* err) = 0;
     /// 更新表格Schema
     virtual bool UpdateTable(const TableDescriptor& desc, ErrorCode* err) = 0;
+    virtual bool UpdateCheck(const std::string& table_name, bool* done, ErrorCode* err) = 0;
     /// 删除表格
-    virtual bool DeleteTable(std::string name, ErrorCode* err) = 0;
+    virtual bool DeleteTable(const std::string& name, ErrorCode* err) = 0;
     /// 停止表格服务
-    virtual bool DisableTable(std::string name, ErrorCode* err) = 0;
+    virtual bool DisableTable(const std::string& name, ErrorCode* err) = 0;
     /// 恢复表格服务
-    virtual bool EnableTable(std::string name, ErrorCode* err) = 0;
+    virtual bool EnableTable(const std::string& name, ErrorCode* err) = 0;
 
     /// acl
     virtual bool CreateUser(const std::string& user,

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -244,6 +244,20 @@ int32_t CreateByFileOp(Client* client, int32_t argc, char** argv, ErrorCode* err
     return 0;
 }
 
+int32_t UpdateCheckOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
+    if (argc != 3) {
+        Usage(argv[0]);
+        return -1;
+    }
+    bool done = false;
+    if (!client->UpdateCheck(argv[2], &done, err)) {
+        std::cerr << err->GetReason() << std::endl;
+        return -1;
+    }
+    std::cout << "update " << (done ? "successed" : "is running...") << std::endl;
+    return 0;
+}
+
 int32_t UpdateOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
     if (argc != 3) {
         Usage(argv[0]);
@@ -2602,6 +2616,8 @@ int ExecuteCommand(Client* client, int argc, char* argv[]) {
         ret = CreateByFileOp(client, argc, argv, &error_code);
     } else if (cmd == "update") {
         ret = UpdateOp(client, argc, argv, &error_code);
+    } else if (cmd == "update-check") {
+        ret = UpdateCheckOp(client, argc, argv, &error_code);
     } else if (cmd == "drop") {
         ret = DropOp(client, argc, argv, &error_code);
     } else if (cmd == "enable") {


### PR DESCRIPTION
当client发起schema更新请求之后，可能因为rpc超时等原因导致“还未获知update-schema的结果，rpc请求就已经中断或返回”。
给用户提供一个check接口，用以应对这种情形。

```
[taocipian@matrix] % ./teracli update-check test-table
update is running...
[taocipian@matrix] % ./teracli update-check test-table
update successed
```