### PR TITLE
issue=#437 online-schema-change:sdk

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -24,6 +24,7 @@
 #include "proto/proto_helper.h"
 #include "proto/tabletnode_client.h"
 #include "utils/config_utils.h"
+#include "utils/schema_utils.h"
 #include "utils/string_util.h"
 #include "utils/timer.h"
 #include "utils/utils_cmd.h"
@@ -97,7 +98,7 @@ DECLARE_bool(tera_only_root_create_table);
 DECLARE_string(tera_master_gc_strategy);
 
 DECLARE_string(flagfile);
-DECLARE_bool(tera_master_online_schema_update_enabled);
+DECLARE_bool(tera_online_schema_update_enabled);
 DECLARE_int32(tera_master_schema_update_retry_period);
 DECLARE_int32(tera_master_schema_update_retry_times);
 
@@ -1001,7 +1002,7 @@ void MasterImpl::UpdateTable(const UpdateTableRequest* request,
         done->Run();
         return;
     }
-    if (FLAGS_tera_master_online_schema_update_enabled
+    if (FLAGS_tera_online_schema_update_enabled
         && !table->GetSchemaSyncLockOrFailed()) {
         // there is a online-schema-update is doing...
         LOG(INFO) << "[update] no concurrent online-schema-update, table:" << table;
@@ -4488,15 +4489,17 @@ void MasterImpl::UpdateTableRecordForUpdateCallback(TablePtr table, int32_t retr
         }
         return;
     }
+    bool is_update_cf = IsSchemaCfDiff(table->GetSchema(), *schema);
     table->SetSchema(*schema);
     if ((table->GetStatus() == kTableDisable) // no need to sync
-        || !FLAGS_tera_master_online_schema_update_enabled) {
+        || !FLAGS_tera_online_schema_update_enabled
+        || !is_update_cf) {
         LOG(INFO) << "[update] new table schema is updated: " << schema->ShortDebugString();
+        table->SetSchemaIsSyncing(false); // releases the schema-sync lock
         rpc_response->set_status(kMasterOk);
         rpc_done->Run();
     } else {
         LOG(INFO) << "[update] online-schema-update";
-        table->SetSchemaIsSyncing(true);
         table->StoreUpdateRpc(rpc_response, rpc_done);
         table->ResetRangeFragment();
         NoticeTabletNodeSchemaUpdated(table);
@@ -5055,7 +5058,7 @@ void MasterImpl::ProcessReadyTablet(TabletPtr tablet) {
         return;
     }
 
-    if (FLAGS_tera_master_online_schema_update_enabled
+    if (FLAGS_tera_online_schema_update_enabled
         && tablet->GetTable()->GetSchemaIsSyncing()
         && !tablet->GetTable()->IsSchemaSyncedAtRange(tablet->GetKeyStart(), tablet->GetKeyEnd())) {
         LOG(INFO) << "[update] tablet ready but schema not synced: " << tablet;

--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -546,7 +546,7 @@ bool CheckTableDescrptor(const TableDescriptor& desc, ErrorCode* err) {
     return true;
 }
 
-bool UpdateCfProperties(PropTree::Node* table_node, TableDescriptor* table_desc) {
+bool UpdateCfProperties(const PropTree::Node* table_node, TableDescriptor* table_desc) {
     if (table_node == NULL || table_desc == NULL) {
         return false;
     }
@@ -592,7 +592,7 @@ bool UpdateCfProperties(PropTree::Node* table_node, TableDescriptor* table_desc)
     return true;
 }
 
-bool UpdateLgProperties(PropTree::Node* table_node, TableDescriptor* table_desc) {
+bool UpdateLgProperties(const PropTree::Node* table_node, TableDescriptor* table_desc) {
     if (table_node == NULL || table_desc == NULL) {
         return false;
     }
@@ -618,11 +618,11 @@ bool UpdateLgProperties(PropTree::Node* table_node, TableDescriptor* table_desc)
     return true;
 }
 
-bool UpdateTableProperties(PropTree::Node* table_node, TableDescriptor* table_desc) {
+bool UpdateTableProperties(const PropTree::Node* table_node, TableDescriptor* table_desc) {
     if (table_node == NULL || table_desc == NULL) {
         return false;
     }
-    for (std::map<string, string>::iterator i = table_node->properties_.begin();
+    for (std::map<string, string>::const_iterator i = table_node->properties_.begin();
          i != table_node->properties_.end(); ++i) {
         if (i->first == "rawkey") {
             LOG(ERROR) << "[update] can't reset rawkey!";
@@ -637,8 +637,7 @@ bool UpdateTableProperties(PropTree::Node* table_node, TableDescriptor* table_de
     return true;
 }
 
-bool UpdateKvTableProperties(PropTree::Node* table_node,
-                             TableDescriptor* table_desc, bool* is_update_lg_cf) {
+bool UpdateKvTableProperties(const PropTree::Node* table_node, TableDescriptor* table_desc) {
     if (table_node == NULL || table_desc == NULL) {
         return false;
     }
@@ -648,14 +647,14 @@ bool UpdateKvTableProperties(PropTree::Node* table_node,
         LOG(ERROR) << "[update] fail to get locality group: kv";
         return false;
     }
-    for (std::map<string, string>::iterator i = table_node->properties_.begin();
+    for (std::map<string, string>::const_iterator i = table_node->properties_.begin();
          i != table_node->properties_.end(); ++i) {
         if (i->first == "rawkey") {
             LOG(ERROR) << "[update] can't reset rawkey!";
             return false;
         }
         if (SetLgProperties(i->first, i->second, lg_desc)) {
-            *is_update_lg_cf = true;
+            // do nothing
         } else if (!SetTableProperties(i->first, i->second, table_desc)) {
             LOG(ERROR) << "[update] illegal value: " << i->second
                 << " for table property: " << i->first;
@@ -665,36 +664,33 @@ bool UpdateKvTableProperties(PropTree::Node* table_node,
     return true;
 }
 
-bool UpdateTableDescriptor(PropTree& schema_tree, TableDescriptor* table_desc,
-                           bool* is_update_lg_cf, ErrorCode* err) {
+bool UpdateTableDescriptor(PropTree& schema_tree, TableDescriptor* table_desc, ErrorCode* err) {
     PropTree::Node* table_node = schema_tree.GetRootNode();
     if (table_node == NULL || table_desc == NULL) {
         return false;
     }
-    bool is_update_ok = false;
+    bool is_ok = false;
     if (table_desc->RawKey() == kTTLKv || table_desc->RawKey() == kGeneralKv) {
         if (schema_tree.MaxDepth() != 1) {
             LOG(ERROR) << "invalid schema for kv table: " << table_node->name_;
             return false;
         }
-        is_update_ok = UpdateKvTableProperties(table_node, table_desc, is_update_lg_cf);
+        is_ok = UpdateKvTableProperties(table_node, table_desc);
     } else if (schema_tree.MaxDepth() == 1) {
         // updates table properties, no updates for lg & cf properties
-        is_update_ok = UpdateTableProperties(table_node, table_desc);
+        is_ok = UpdateTableProperties(table_node, table_desc);
     } else if (schema_tree.MaxDepth() == 2) {
-        *is_update_lg_cf = true;
-        is_update_ok = UpdateLgProperties(table_node, table_desc) &&
-               UpdateTableProperties(table_node, table_desc);
+        is_ok = UpdateLgProperties(table_node, table_desc)
+                && UpdateTableProperties(table_node, table_desc);
     } else if (schema_tree.MaxDepth() == 3) {
-        *is_update_lg_cf = true;
-        is_update_ok =  UpdateCfProperties(table_node, table_desc) &&
-                        UpdateLgProperties(table_node, table_desc) &&
-                        UpdateTableProperties(table_node, table_desc);
+        is_ok =  UpdateCfProperties(table_node, table_desc)
+                 && UpdateLgProperties(table_node, table_desc)
+                 && UpdateTableProperties(table_node, table_desc);
     } else {
         LOG(ERROR) << "invalid schema";
         return false;
     }
-    if (is_update_ok) {
+    if (is_ok) {
         return CheckTableDescrptor(*table_desc, err);
     }
     return false;

--- a/src/sdk/sdk_utils.h
+++ b/src/sdk/sdk_utils.h
@@ -33,8 +33,7 @@ bool SetTableProperties(const string& name, const string& value,
                         TableDescriptor* desc);
 
 bool FillTableDescriptor(PropTree& schema_tree, TableDescriptor* desc);
-bool UpdateTableDescriptor(PropTree& schema_tree, TableDescriptor* table_desc,
-                           bool* is_update_lg_cf, ErrorCode* err);
+bool UpdateTableDescriptor(PropTree& schema_tree, TableDescriptor* table_desc, ErrorCode* err);
 bool CheckTableDescrptor(const TableDescriptor& desc, ErrorCode* err);
 
 bool ParseTableSchema(const string& schema, TableDescriptor* table_desc, ErrorCode* err);

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -29,6 +29,7 @@ DEFINE_int32(tera_zk_retry_max_times, 10, "zookeeper operation max retry times")
 DEFINE_string(tera_zk_lib_log_path, "../log/zk.log", "zookeeper library log output file");
 DEFINE_string(tera_log_prefix, "", "prefix of log file (INFO, WARNING)");
 DEFINE_string(tera_local_addr, "", "local host's ip address");
+DEFINE_bool(tera_online_schema_update_enabled, false, "enable online-schema-update");
 
 /////////  io  /////////
 
@@ -109,7 +110,6 @@ DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tablet
 DEFINE_int32(tera_master_max_move_concurrency, 50, "the max concurrency for move tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 
-DEFINE_bool(tera_master_online_schema_update_enabled, false, "enable online-schema-update");
 DEFINE_int32(tera_master_schema_update_retry_period, 1, "the period (in second) to poll schema update");
 DEFINE_int32(tera_master_schema_update_retry_times, 60000, "the max retry times of syncing new schema to ts");
 

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -263,15 +263,8 @@ int32_t UpdateOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
         return -1;
     }
 
-    // if try to update lg or cf, need to disable table
-    bool is_update_lg_cf = false;
-    if (!UpdateTableDescriptor(schema_tree, table_desc, &is_update_lg_cf, err)) {
+    if (!UpdateTableDescriptor(schema_tree, table_desc, err)) {
         LOG(ERROR) << "[update] update failed";
-        return -1;
-    }
-
-    if (is_update_lg_cf && client->IsTableEnabled(table_desc->TableName(), err)) {
-        LOG(ERROR) << "[update] table is enabled, disable it first: " << table_desc->TableName();
         return -1;
     }
 

--- a/src/utils/schema_utils.cc
+++ b/src/utils/schema_utils.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "utils/schema_utils.h"
+
+#include <sstream>
+
+#include <glog/logging.h>
+
+namespace tera {
+
+bool IsSchemaCfDiff(const TableSchema& a, const TableSchema& b) {
+    std::stringstream s0;
+    std::stringstream s1;
+    for (int i = 0; i < a.column_families_size(); ++i) {
+        s0 << a.column_families(i).ShortDebugString();
+    }
+    LOG(INFO) << "[utils] " << s0.str();
+    for (int i = 0; i < b.column_families_size(); ++i) {
+        s1 << b.column_families(i).ShortDebugString();
+    }
+    LOG(INFO) << "[utils] " << s1.str();
+    return (s0.str().compare(s1.str()) != 0);
+}
+
+bool IsSchemaLgDiff(const TableSchema& a, const TableSchema& b) {
+    std::stringstream s0;
+    std::stringstream s1;
+    for (int i = 0; i < a.locality_groups_size(); ++i) {
+        s0 << a.locality_groups(i).ShortDebugString();
+    }
+    LOG(INFO) << "[utils] " << s0.str();
+    for (int i = 0; i < b.locality_groups_size(); ++i) {
+        s1 << b.locality_groups(i).ShortDebugString();
+    }
+    LOG(INFO) << "[utils] " << s1.str();
+    return (s0.str().compare(s1.str()) != 0);
+}
+
+} // namespace tera

--- a/src/utils/schema_utils.h
+++ b/src/utils/schema_utils.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TERA_SCHEMA_UTILS_H_
+#define TERA_SCHEMA_UTILS_H_
+
+#include "proto/table_schema.pb.h"
+
+namespace tera {
+
+bool IsSchemaCfDiff(const TableSchema& a, const TableSchema& b);
+
+bool IsSchemaLgDiff(const TableSchema& a, const TableSchema& b);
+
+} // namespace tera
+
+#endif // TERA_SCHEMA_UTILS_H_


### PR DESCRIPTION
在线schema更新：sdk部分

有一个小优化，如果检测到schema更新仅仅涉及表格级属性（例如splitsize），而cf的属性无变化，则不用涉及ts，仅仅由master自己就能搞定。