### PR TITLE
update flash_env: copy to local background and read dfs temporary 

### DIFF
--- a/src/leveldb/include/leveldb/env_flash.h
+++ b/src/leveldb/include/leveldb/env_flash.h
@@ -63,19 +63,19 @@ public:
     Env* BaseEnv() { return dfs_env_; }
 
     /// flash path for local flash cache
-    static void SetFlashPath(const std::string& path, bool vanish_allowed);
-    static const std::string& FlashPath(const std::string& fname);
-    static const bool VanishAllowed() {
+    void SetFlashPath(const std::string& path, bool vanish_allowed);
+    const std::string& FlashPath(const std::string& fname);
+    const bool VanishAllowed() {
         return vanish_allowed_;
     }
-    static const std::vector<std::string>& GetFlashPaths() {
+    const std::vector<std::string>& GetFlashPaths() {
         return flash_paths_;
     }
 
     /// copy to local
-    static void SetIfForceReadFromCache(bool force);
-    static bool ForceReadFromCache();
-    static void SetUpdateFlashThreadNumber(int thread_num);
+    void SetIfForceReadFromCache(bool force);
+    bool ForceReadFromCache();
+    void SetUpdateFlashThreadNumber(int thread_num);
 
     bool FlashFileIdentical(const std::string& fname, uint64_t fsize);
     void ScheduleUpdateFlash(const std::string& fname, uint64_t fsize, int64_t priority);
@@ -85,11 +85,11 @@ private:
     Env* dfs_env_;
     Env* posix_env_;
 
-    static std::vector<std::string> flash_paths_;
-    static bool vanish_allowed_;
+    std::vector<std::string> flash_paths_;
+    bool vanish_allowed_;
 
-    static bool force_read_from_cache_;
-    static ThreadPool update_flash_threads_;
+    bool force_read_from_cache_;
+    ThreadPool update_flash_threads_;
     port::Mutex update_flash_mutex_;
     struct UpdateFlashTask {
         int64_t id;

--- a/src/leveldb/include/leveldb/env_flash.h
+++ b/src/leveldb/include/leveldb/env_flash.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include "env.h"
 #include "status.h"
+#include "util/thread_pool.h"
 
 
 namespace leveldb {
@@ -59,18 +60,43 @@ public:
 
     virtual Env* CacheEnv() { return posix_env_; }
 
+    Env* BaseEnv() { return dfs_env_; }
+
     /// flash path for local flash cache
     static void SetFlashPath(const std::string& path, bool vanish_allowed);
     static const std::string& FlashPath(const std::string& fname);
+    static const bool VanishAllowed() {
+        return vanish_allowed_;
+    }
     static const std::vector<std::string>& GetFlashPaths() {
         return flash_paths_;
     }
 
+    /// copy to local
+    static void SetIfForceReadFromCache(bool force);
+    static bool ForceReadFromCache();
+    static void SetUpdateFlashThreadNumber(int thread_num);
+
+    bool FlashFileIdentical(const std::string& fname, uint64_t fsize);
+    void ScheduleUpdateFlash(const std::string& fname, uint64_t fsize, int64_t priority);
+    void UpdateFlashFile(const std::string& fname, uint64_t fsize);
+
 private:
     Env* dfs_env_;
     Env* posix_env_;
+
     static std::vector<std::string> flash_paths_;
     static bool vanish_allowed_;
+
+    static bool force_read_from_cache_;
+    static ThreadPool update_flash_threads_;
+    port::Mutex update_flash_mutex_;
+    struct UpdateFlashTask {
+        int64_t id;
+        int64_t priority;
+    };
+    std::map<std::string, UpdateFlashTask> update_flash_waiting_files_;
+    int64_t update_flash_retry_interval_millis_;
 };
 
 /// new flash env

--- a/src/leveldb/util/env_flash.cc
+++ b/src/leveldb/util/env_flash.cc
@@ -559,14 +559,14 @@ void FlashEnv::ScheduleUpdateFlash(const std::string& fname, uint64_t fsize, int
         UpdateFlashTask& task = update_flash_waiting_files_[fname];
         task.priority = priority;
         task.id = update_flash_threads_.Schedule(UpdateFlashFileFunc, param, (double)task.priority, 0);
-        Log("[env_flash] schedule copy to local, id: %ld, prio: %ld, file: %s\n",
-            task.id, task.priority, fname.c_str());
+        Log("[env_flash] schedule copy to local, id: %ld, prio: %ld, file: %s, pend: %ld\n",
+            task.id, task.priority, fname.c_str(), update_flash_threads_.GetPendingTaskNum());
     } else {
         UpdateFlashTask& task = update_flash_waiting_files_[fname];
         task.priority += priority;
         update_flash_threads_.ReSchedule(task.id, (double)task.priority, 0);
-        Log("[env_flash] reschedule copy to local, id: %ld, prio: %ld, file: %s\n",
-            task.id, task.priority, fname.c_str());
+        Log("[env_flash] reschedule copy to local, id: %ld, prio: %ld, file: %s, pend: %ld\n",
+            task.id, task.priority, fname.c_str(), update_flash_threads_.GetPendingTaskNum());
     }
 }
 
@@ -577,13 +577,14 @@ void FlashEnv::UpdateFlashFile(const std::string& fname, uint64_t fsize) {
     MutexLock l(&update_flash_mutex_);
     if (copy_status.ok()) {
         UpdateFlashTask& task = update_flash_waiting_files_[fname];
-        Log("[env_flash] copy to local success, id: %ld, prio: %ld, file: %s\n",
-            task.id, task.priority, local_fname.c_str());
+        Log("[env_flash] copy to local success, id: %ld, prio: %ld, file: %s, pend: %ld\n",
+            task.id, task.priority, local_fname.c_str(), update_flash_threads_.GetPendingTaskNum());
         update_flash_waiting_files_.erase(fname);
     } else {
         UpdateFlashTask& task = update_flash_waiting_files_[fname];
-        Log("[env_flash] copy to local fail [%s], id: %ld, prio: %ld, file: %s\n",
-            copy_status.ToString().c_str(), task.id, task.priority, local_fname.c_str());
+        Log("[env_flash] copy to local fail [%s], id: %ld, prio: %ld, file: %s, pend: %ld\n",
+            copy_status.ToString().c_str(), task.id, task.priority,
+            local_fname.c_str(), update_flash_threads_.GetPendingTaskNum());
 
         UpdateFlashFileParam* param = new UpdateFlashFileParam;
         param->flash_env = this;

--- a/src/leveldb/util/env_flash.cc
+++ b/src/leveldb/util/env_flash.cc
@@ -591,13 +591,15 @@ void FlashEnv::UpdateFlashFile(const std::string& fname, uint64_t fsize) {
         param->fsize = fsize;
 
         task.priority >>= 1; // cut down priority to half
-        if (task.priority < 1) {
-            task.priority = 1;
+        if (task.priority > 0) {
+            task.id = update_flash_threads_.Schedule(UpdateFlashFileFunc, param, (double)task.priority,
+                                                     update_flash_retry_interval_millis_);
+            Log("[env_flash] schedule copy to local after %ld ms, id: %ld, prio: %ld, file: %s\n",
+                update_flash_retry_interval_millis_, task.id, task.priority, local_fname.c_str());
+        } else {
+            Log("[env_flash] abort schedule copy to local, file: %s\n", local_fname.c_str());
+            update_flash_waiting_files_.erase(fname);
         }
-        task.id = update_flash_threads_.Schedule(UpdateFlashFileFunc, param, (double)task.priority,
-                                                 update_flash_retry_interval_millis_);
-        Log("[env_flash] schedule copy to local after %ld ms, id: %ld, prio: %ld, file: %s\n",
-            update_flash_retry_interval_millis_, task.id, task.priority, local_fname.c_str());
     }
 }
 

--- a/src/leveldb/util/env_flash.cc
+++ b/src/leveldb/util/env_flash.cc
@@ -33,6 +33,9 @@ tera::Counter ssd_read_size_counter;
 tera::Counter ssd_write_counter;
 tera::Counter ssd_write_size_counter;
 
+const int64_t kFlashFileCheckIntervalMicros = 30 * 1000000;
+const int64_t kUpdateFlashRetryIntervalMillis = 60 * 1000;
+
 // Log error message
 static Status IOError(const std::string& context, int err_number) {
     return Status::IOError(context, strerror(err_number));
@@ -104,6 +107,8 @@ Status CopyToLocal(const std::string& local_fname, Env* env,
         return Status::IOError("dfs GetFileSize fail", s.ToString());
     }
 
+    Log("[env_flash] copy %s to local fail, size %ld, dfs size %ld, local size %ld\n",
+        fname.c_str(), fsize, file_size, local_size);
     if (fsize == file_size) {
         // dfs fsize match but local doesn't match
         s = IOError("local fsize mismatch", file_size);
@@ -153,41 +158,105 @@ public:
 // A file abstraction for randomly reading the contents of a file.
 class FlashRandomAccessFile :public RandomAccessFile{
 private:
-    RandomAccessFile* dfs_file_;
-    RandomAccessFile* flash_file_;
-public:
-    FlashRandomAccessFile(Env* posix_env, Env* dfs_env, const std::string& fname,
-                          uint64_t fsize, bool vanish_allowed)
-        :dfs_file_(NULL), flash_file_(NULL) {
-        std::string local_fname = FlashEnv::FlashPath(fname) + fname;
+    FlashEnv* flash_env_;
+    mutable RandomAccessFile* dfs_file_;
+    mutable RandomAccessFile* flash_file_;
+    std::string fname_;
+    std::string local_fname_;
+    uint64_t fsize_;
 
-        // copy from dfs with seq read
-        Status copy_status = CopyToLocal(local_fname, dfs_env, fname, fsize,
-                                         vanish_allowed);
-        if (!copy_status.ok()) {
-            Log("[env_flash] copy to local fail [%s]: %s\n",
-                copy_status.ToString().c_str(), local_fname.c_str());
-            // no flash file, use dfs file
-            dfs_env->NewRandomAccessFile(fname, &dfs_file_);
+    mutable port::Mutex mutex_;
+    mutable bool flash_file_is_checking_;
+    mutable uint64_t flash_file_last_check_micros_;
+    mutable uint64_t flash_file_check_interval_micros_;
+    mutable uint64_t read_dfs_count_;
+public:
+    FlashRandomAccessFile(FlashEnv* flash_env, const std::string& fname, uint64_t fsize)
+        : flash_env_(flash_env), dfs_file_(NULL), flash_file_(NULL), fname_(fname),
+          local_fname_(FlashEnv::FlashPath(fname) + fname), fsize_(fsize),
+          flash_file_is_checking_(false), flash_file_last_check_micros_(0),
+          flash_file_check_interval_micros_(kFlashFileCheckIntervalMicros),
+          read_dfs_count_(0) {
+
+        if (!flash_env_->ForceReadFromCache()) {
+            if (flash_env_->FlashFileIdentical(fname, fsize)) {
+                Status s = flash_env_->CacheEnv()->NewRandomAccessFile(local_fname_, &flash_file_);
+                if (s.ok()) {
+                    return;
+                }
+                Log("[env_flash] local file exists, but open for RandomAccess fail: %s\n",
+                    local_fname_.c_str());
+            } else {
+                Log("[env_flash] local file not exists: %s\n", local_fname_.c_str());
+            }
+            flash_env_->ScheduleUpdateFlash(fname, fsize, 1);
+            flash_env_->BaseEnv()->NewRandomAccessFile(fname, &dfs_file_);
+            flash_file_last_check_micros_ = Env::Default()->NowMicros();
             return;
         }
 
-        Status s = posix_env->NewRandomAccessFile(local_fname, &flash_file_);
+        // copy from dfs with seq read
+        Status copy_status = CopyToLocal(local_fname_, flash_env_->BaseEnv(), fname, fsize,
+                                         flash_env_->VanishAllowed());
+        if (!copy_status.ok()) {
+            Log("[env_flash] copy to local fail [%s]: %s\n",
+                copy_status.ToString().c_str(), local_fname_.c_str());
+            // no flash file, use dfs file
+            flash_env_->BaseEnv()->NewRandomAccessFile(fname, &dfs_file_);
+            return;
+        }
+        Status s = flash_env_->CacheEnv()->NewRandomAccessFile(local_fname_, &flash_file_);
         if (s.ok()) {
             return;
         }
         Log("[env_flash] local file exists, but open for RandomAccess fail: %s\n",
-            local_fname.c_str());
-        Env::Default()->DeleteFile(local_fname);
-        dfs_env->NewRandomAccessFile(fname, &dfs_file_);
+            local_fname_.c_str());
+        flash_env_->CacheEnv()->DeleteFile(local_fname_);
+        flash_env_->BaseEnv()->NewRandomAccessFile(fname, &dfs_file_);
     }
     ~FlashRandomAccessFile() {
         delete dfs_file_;
         delete flash_file_;
     }
-    Status Read(uint64_t offset, size_t n, Slice* result,
-                      char* scratch) const {
-        if (flash_file_) {
+    Status Read(uint64_t offset, size_t n, Slice* result, char* scratch) const {
+        bool use_flash = false;
+        if (!flash_env_->ForceReadFromCache()) {
+            MutexLock l(&mutex_);
+            // evenry 30 seconds, check if flash file is identical to dfs file.
+            // if so, try open flash file;
+            // else, reschedule update it with a higher priority
+            if (flash_file_ == NULL &&
+                    !flash_file_is_checking_ &&
+                    flash_file_last_check_micros_ + flash_file_check_interval_micros_
+                        <= Env::Default()->NowMicros()) {
+                flash_file_is_checking_ = true;
+                mutex_.Unlock();
+                RandomAccessFile* tmp_file = NULL;
+                if (flash_env_->FlashFileIdentical(fname_, fsize_)) {
+                    flash_env_->CacheEnv()->NewRandomAccessFile(local_fname_, &tmp_file);
+                }
+                mutex_.Lock();
+                if (tmp_file != NULL) {
+                    flash_file_ = tmp_file;
+                    Log("[env_flash] switch to local file: %s\n", local_fname_.c_str());
+                } else {
+                    flash_env_->ScheduleUpdateFlash(fname_, fsize_, read_dfs_count_);
+                    read_dfs_count_ = 0;
+                }
+                flash_file_is_checking_ = false;
+                flash_file_last_check_micros_ = Env::Default()->NowMicros();
+            }
+            if (flash_file_ != NULL) {
+                use_flash = true;
+            } else {
+                ++read_dfs_count_;
+            }
+        } else {
+            if (flash_file_ != NULL) {
+                use_flash = true;
+            }
+        }
+        if (use_flash) {
             Status read_status = flash_file_->Read(offset, n, result, scratch);
             if (read_status.ok()) {
                 ssd_read_counter.Inc();
@@ -305,10 +374,10 @@ public:
 
 std::vector<std::string> FlashEnv::flash_paths_(1, "./flash");
 
-FlashEnv::FlashEnv(Env* base_env) : EnvWrapper(Env::Default())
+FlashEnv::FlashEnv(Env* base_env)
+  : EnvWrapper(Env::Default()), dfs_env_(base_env), posix_env_(Env::Default()),
+    update_flash_retry_interval_millis_(kUpdateFlashRetryIntervalMillis)
 {
-    dfs_env_ = base_env;
-    posix_env_ = Env::Default();
 }
 
 FlashEnv::~FlashEnv()
@@ -333,8 +402,7 @@ Status FlashEnv::NewRandomAccessFile(const std::string& fname,
         uint64_t fsize, RandomAccessFile** result)
 {
     FlashRandomAccessFile* f =
-        new FlashRandomAccessFile(posix_env_, dfs_env_, fname,
-                                  fsize, vanish_allowed_);
+        new FlashRandomAccessFile(this, fname, fsize);
     if (f == NULL || !f->isValid()) {
         *result = NULL;
         delete f;
@@ -458,7 +526,96 @@ const std::string& FlashEnv::FlashPath(const std::string& fname) {
     return flash_paths_[hash % flash_paths_.size()];
 }
 
+void FlashEnv::SetIfForceReadFromCache(bool force) {
+    force_read_from_cache_ = force;
+}
+
+bool FlashEnv::ForceReadFromCache() {
+    return force_read_from_cache_;
+}
+
+void FlashEnv::SetUpdateFlashThreadNumber(int thread_num) {
+    update_flash_threads_.SetBackgroundThreads(thread_num);
+}
+
+bool FlashEnv::FlashFileIdentical(const std::string& fname, uint64_t fsize) {
+    uint64_t local_size = 0;
+    std::string local_fname = FlashEnv::FlashPath(fname) + fname;
+    Status s = Env::Default()->GetFileSize(local_fname, &local_size);
+    if (s.ok() && fsize == local_size) {
+        return true;
+    }
+    return false;
+}
+
+struct UpdateFlashFileParam {
+    FlashEnv* flash_env;
+    std::string fname;
+    uint64_t fsize;
+};
+
+void UpdateFlashFileFunc(void* arg) {
+    UpdateFlashFileParam* update_arg = (UpdateFlashFileParam*)arg;
+    update_arg->flash_env->UpdateFlashFile(update_arg->fname, update_arg->fsize);
+    delete update_arg;
+}
+
+void FlashEnv::ScheduleUpdateFlash(const std::string& fname, uint64_t fsize, int64_t priority) {
+    MutexLock l(&update_flash_mutex_);
+    if (update_flash_waiting_files_.find(fname) == update_flash_waiting_files_.end()) {
+        UpdateFlashFileParam* param = new UpdateFlashFileParam;
+        param->flash_env = this;
+        param->fname = fname;
+        param->fsize = fsize;
+
+        UpdateFlashTask& task = update_flash_waiting_files_[fname];
+        task.priority = priority;
+        task.id = update_flash_threads_.Schedule(UpdateFlashFileFunc, param, (double)task.priority, 0);
+        Log("[env_flash] schedule copy to local, id: %ld, prio: %ld, file: %s\n",
+            task.id, task.priority, fname.c_str());
+    } else {
+        UpdateFlashTask& task = update_flash_waiting_files_[fname];
+        task.priority += priority;
+        update_flash_threads_.ReSchedule(task.id, (double)task.priority, 0);
+        Log("[env_flash] reschedule copy to local, id: %ld, prio: %ld, file: %s\n",
+            task.id, task.priority, fname.c_str());
+    }
+}
+
+void FlashEnv::UpdateFlashFile(const std::string& fname, uint64_t fsize) {
+    std::string local_fname = FlashEnv::FlashPath(fname) + fname;
+    Status copy_status = CopyToLocal(local_fname, dfs_env_, fname, fsize, vanish_allowed_);
+
+    MutexLock l(&update_flash_mutex_);
+    if (copy_status.ok()) {
+        UpdateFlashTask& task = update_flash_waiting_files_[fname];
+        Log("[env_flash] copy to local success, id: %ld, prio: %ld, file: %s\n",
+            task.id, task.priority, local_fname.c_str());
+        update_flash_waiting_files_.erase(fname);
+    } else {
+        UpdateFlashTask& task = update_flash_waiting_files_[fname];
+        Log("[env_flash] copy to local fail [%s], id: %ld, prio: %ld, file: %s\n",
+            copy_status.ToString().c_str(), task.id, task.priority, local_fname.c_str());
+
+        UpdateFlashFileParam* param = new UpdateFlashFileParam;
+        param->flash_env = this;
+        param->fname = fname;
+        param->fsize = fsize;
+
+        task.priority >>= 1; // cut down priority to half
+        if (task.priority < 1) {
+            task.priority = 1;
+        }
+        task.id = update_flash_threads_.Schedule(UpdateFlashFileFunc, param, (double)task.priority,
+                                                 update_flash_retry_interval_millis_);
+        Log("[env_flash] schedule copy to local after %ld ms, id: %ld, prio: %ld, file: %s\n",
+            update_flash_retry_interval_millis_, task.id, task.priority, local_fname.c_str());
+    }
+}
+
 bool FlashEnv::vanish_allowed_ = false;
+bool FlashEnv::force_read_from_cache_ = true;
+ThreadPool FlashEnv::update_flash_threads_;
 
 Env* NewFlashEnv(Env* base_env)
 {

--- a/src/leveldb/util/thread_pool.h
+++ b/src/leveldb/util/thread_pool.h
@@ -32,6 +32,7 @@ public:
   // Return maximal allowed thread number
   int GetThreadNumber();
   void SetLogger(Logger* info_log) { info_log_ = info_log; }
+  int64_t GetPendingTaskNum();
 
 private:
   struct BGItem {
@@ -67,6 +68,7 @@ private:
   bool exit_all_threads_;
   int64_t last_item_id_;
   int active_number_;
+  int64_t pending_task_num_;
 
   Logger* info_log_;
   port::Mutex mutex_;

--- a/src/tabletnode/tabletnode_impl.cc
+++ b/src/tabletnode/tabletnode_impl.cc
@@ -171,10 +171,11 @@ bool TabletNodeImpl::Init() {
 void TabletNodeImpl::InitCacheSystem() {
     if (!FLAGS_tera_tabletnode_cache_enabled) {
         // compitable with legacy FlashEnv
-        leveldb::FlashEnv::SetFlashPath(FLAGS_tera_tabletnode_cache_paths,
-                                        FLAGS_tera_io_cache_path_vanish_allowed);
-        leveldb::FlashEnv::SetUpdateFlashThreadNumber(FLAGS_tera_tabletnode_cache_update_thread_num);
-        leveldb::FlashEnv::SetIfForceReadFromCache(FLAGS_tera_tabletnode_cache_force_read_from_cache);
+        leveldb::FlashEnv* flash_env = (leveldb::FlashEnv*)io::LeveldbFlashEnv();
+        flash_env->SetFlashPath(FLAGS_tera_tabletnode_cache_paths,
+                                FLAGS_tera_io_cache_path_vanish_allowed);
+        flash_env->SetUpdateFlashThreadNumber(FLAGS_tera_tabletnode_cache_update_thread_num);
+        flash_env->SetIfForceReadFromCache(FLAGS_tera_tabletnode_cache_force_read_from_cache);
         return;
     }
 
@@ -1021,7 +1022,8 @@ void TabletNodeImpl::GarbageCollect() {
     }
 
     // collect flash directories
-    const std::vector<std::string>& flash_paths = leveldb::FlashEnv::GetFlashPaths();
+    leveldb::FlashEnv* flash_env = (leveldb::FlashEnv*)io::LeveldbFlashEnv();
+    const std::vector<std::string>& flash_paths = flash_env->GetFlashPaths();
     for (size_t d = 0; d < flash_paths.size(); ++d) {
         std::string flash_dir = flash_paths[d] + FLAGS_tera_tabletnode_path_prefix;
         GarbageCollectInPath(flash_dir, leveldb::Env::Default(),

--- a/src/tabletnode/tabletnode_impl.cc
+++ b/src/tabletnode/tabletnode_impl.cc
@@ -73,6 +73,8 @@ DECLARE_int32(tera_tabletnode_cache_mem_size);
 DECLARE_int32(tera_tabletnode_cache_disk_size);
 DECLARE_int32(tera_tabletnode_cache_disk_filenum);
 DECLARE_int32(tera_tabletnode_cache_log_level);
+DECLARE_int32(tera_tabletnode_cache_update_thread_num);
+DECLARE_bool(tera_tabletnode_cache_force_read_from_cache);
 DECLARE_int32(tera_tabletnode_gc_log_level);
 
 DECLARE_string(tera_leveldb_env_type);
@@ -171,6 +173,8 @@ void TabletNodeImpl::InitCacheSystem() {
         // compitable with legacy FlashEnv
         leveldb::FlashEnv::SetFlashPath(FLAGS_tera_tabletnode_cache_paths,
                                         FLAGS_tera_io_cache_path_vanish_allowed);
+        leveldb::FlashEnv::SetUpdateFlashThreadNumber(FLAGS_tera_tabletnode_cache_update_thread_num);
+        leveldb::FlashEnv::SetIfForceReadFromCache(FLAGS_tera_tabletnode_cache_force_read_from_cache);
         return;
     }
 

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -193,6 +193,8 @@ DEFINE_int32(tera_tabletnode_cache_mem_size, 2048, "the maximal size (in KB) of 
 DEFINE_int32(tera_tabletnode_cache_disk_size, 1024, "the maximal size (in MB) of disk cache");
 DEFINE_int32(tera_tabletnode_cache_disk_filenum, 1, "the file num of disk cache storage");
 DEFINE_int32(tera_tabletnode_cache_log_level, 1, "the log level [0 - 5] for cache system (0: FATAL, 1: ERROR, 2: WARN, 3: INFO, 5: DEBUG).");
+DEFINE_int32(tera_tabletnode_cache_update_thread_num, 4, "thread num for update cache");
+DEFINE_bool(tera_tabletnode_cache_force_read_from_cache, true, "force update cache before any read");
 DEFINE_int32(tera_tabletnode_gc_log_level, 15, "the vlog level [0 - 16] for cache gc.");
 
 DEFINE_bool(tera_tabletnode_tcm_cache_release_enabled, true, "enable the timer to release tcmalloc cache");


### PR DESCRIPTION
#212
open file：
1. 如果FLAG_force_read_from_cache为true，copy to local
2. 如果local file size == dfs file size，open local file； 否则，open dfs file，并向线程池注册copy to local任务，优先级是1
read file：
1. 如果local file没有打开，且没有其他线程正在打开，且距上次尝试打开过了30秒，检查local file size，如果不等于dfs file size，提高copy to local任务优先级，提高数等于期间read次数；否则，打开local file
2. 如果local file打开，read local file，否则read dfs file
copy to local：
1. 执行copy
2. 如果失败，重新向线程池注册copy to local任务，60秒后执行，优先级为原来的一半