### PR TITLE
issue=#776 teracli-prompt-edit-distance

### DIFF
--- a/src/utils/string_util.h
+++ b/src/utils/string_util.h
@@ -19,6 +19,8 @@ namespace tera {
     bool IsValidUserName(const std::string& name);
 
     bool IsValidColumnFamilyName(const std::string& str);
+
+    int EditDistance(const std::string& a, const std::string& b);
 } // namespace tera
 
 #endif  // TERA_UTIL_STRING_UTIL_H_

--- a/src/utils/test/string_util_test.cc
+++ b/src/utils/test/string_util_test.cc
@@ -46,6 +46,32 @@ TEST(StringUtilTest, IsValidCfName) {
     ASSERT_FALSE(IsValidColumnFamilyName("cf0\2"));
 }
 
+TEST(EditDistance, AllCase) {
+    ASSERT_EQ(EditDistance("", ""), 0);
+    ASSERT_EQ(EditDistance("", "a"), 1);
+    ASSERT_EQ(EditDistance("a", ""), 1);
+    ASSERT_EQ(EditDistance("ab", ""), 2);
+    ASSERT_EQ(EditDistance("", "ab"), 2);
+
+    ASSERT_EQ(EditDistance("a", "a"), 0);
+    ASSERT_EQ(EditDistance("a", "b"), 1);
+
+    ASSERT_EQ(EditDistance("ax", "axy"), 1); // insertion
+    ASSERT_EQ(EditDistance("ax", "a"), 1);   // removal
+    ASSERT_EQ(EditDistance("ax", "ay"), 1);  // substitution
+
+    ASSERT_EQ(EditDistance("showschema", "show_schema"), 1);
+    ASSERT_EQ(EditDistance("showschema", "showscheama"), 1);
+    ASSERT_EQ(EditDistance("branch", "branc"), 1);
+    ASSERT_EQ(EditDistance("update", "udpate"), 2);
+
+    ASSERT_EQ(EditDistance("aaa", "bbb"), 3);
+    ASSERT_EQ(EditDistance("aaa", "baa"), 1);
+    ASSERT_EQ(EditDistance("abb", "acc"), 2);
+    ASSERT_EQ(EditDistance("abc", "op"), 3);
+    ASSERT_EQ(EditDistance("abc", "rstuvw"), 6);
+}
+
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
#776 

这个pr有2点改动：
1. 打印全部命令列表时，由原来“一行打印一个command”改为现在的”一行打印两个command“，降低刷屏感，提高可用性；
2. 针对不认识的命令，通过编辑距离猜测几个可能的正确命令，给出提示；没有相似的命令时，打印命令列表。