### PR TITLE
issue=#728 bugfix's bugfix on update

### DIFF
--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -404,7 +404,6 @@ private:
                                             bool failed, int error_code);
 
     void UpdateTableRecordForUpdateCallback(TablePtr table, int32_t retry_times,
-                                            const TableSchema* schema,
                                             UpdateTableResponse* rpc_response,
                                             google::protobuf::Closure* rpc_done,
                                             WriteTabletRequest* request,

--- a/src/master/tablet_manager.cc
+++ b/src/master/tablet_manager.cc
@@ -750,6 +750,27 @@ bool Table::GetSchemaSyncLockOrFailed() {
     return true;
 }
 
+void Table::SetOldSchema(TableSchema* schema) {
+    MutexLock lock(&m_mutex);
+    delete m_old_schema;
+    m_old_schema = schema;
+}
+
+bool Table::GetOldSchema(TableSchema* schema) {
+    MutexLock lock(&m_mutex);
+    if ((schema != NULL) && (m_old_schema != NULL)) {
+        schema->CopyFrom(*m_old_schema);
+        return true;
+    }
+    return false;
+}
+
+void Table::ClearOldSchema() {
+    MutexLock lock(&m_mutex);
+    delete m_old_schema;
+    m_old_schema = NULL;
+}
+
 void Table::ResetRangeFragment() {
     MutexLock lock(&m_mutex);
     delete m_rangefragment;

--- a/src/master/tablet_manager.h
+++ b/src/master/tablet_manager.h
@@ -203,6 +203,9 @@ public:
     void UpdateRpcDone();
     void StoreUpdateRpc(UpdateTableResponse* response, google::protobuf::Closure* done);
     bool IsSchemaSyncedAtRange(const std::string& start, const std::string& end);
+    void SetOldSchema(TableSchema* schema);
+    bool GetOldSchema(TableSchema* schema);
+    void ClearOldSchema();
 
 private:
     Table(const Table&) {}
@@ -223,6 +226,7 @@ private:
     RangeFragment* m_rangefragment;
     UpdateTableResponse* m_update_rpc_response;
     google::protobuf::Closure* m_update_rpc_done;
+    TableSchema* m_old_schema;
 };
 
 class TabletManager {

--- a/src/master/tablet_manager.h
+++ b/src/master/tablet_manager.h
@@ -206,6 +206,9 @@ public:
     void SetOldSchema(TableSchema* schema);
     bool GetOldSchema(TableSchema* schema);
     void ClearOldSchema();
+    bool PrepareUpdate(const TableSchema& schema);
+    void AbortUpdate();
+    void CommitUpdate();
 
 private:
     Table(const Table&) {}


### PR DESCRIPTION
#728 

更新schema
最早的实现：先改master内存，再写meta表，写meta失败无回滚

之后某个bugfix版本（#729）：先写meta表，成功再改内存（有个问题：写meta时拿的仍然是旧数据，因为旧数据在内存中还没被修改），所以新schema没有被持久化下去。

这个版本：先改内存，暂时不向client提交处理结果；再写meta表，如果失败则回滚内存。