### PR TITLE
issue=#780 tablet-availability-show-details

### DIFF
--- a/src/master/availability.cc
+++ b/src/master/availability.cc
@@ -13,9 +13,10 @@
 #include "common/timer.h"
 #include "utils/string_util.h"
 
-DECLARE_int64(tera_master_availability_warning_threshold);
+DECLARE_bool(tera_master_availability_show_details_enabled);
 DECLARE_int64(tera_master_availability_error_threshold);
 DECLARE_int64(tera_master_availability_fatal_threshold);
+DECLARE_int64(tera_master_availability_warning_threshold);
 DECLARE_int64(tera_master_not_available_threshold);
 DECLARE_string(tera_master_meta_table_name);
 DECLARE_string(tera_master_meta_table_path);
@@ -67,8 +68,14 @@ void TabletAvailability::LogAvailability() {
         }
         if ((start - it->second) > FLAGS_tera_master_availability_fatal_threshold * 1000 * 1000LL) {
             not_avai_fatal++;
+            if (FLAGS_tera_master_availability_show_details_enabled) {
+                LOG(INFO) << "[availability] fatal-tablet:" << it->first;
+            }
         } else if ((start - it->second) > FLAGS_tera_master_availability_error_threshold * 1000 * 1000LL) {
             not_avai_error++;
+            if (FLAGS_tera_master_availability_show_details_enabled) {
+                LOG(INFO) << "[availability] error-tablet:" << it->first;
+            }
         } else if ((start - it->second) > FLAGS_tera_master_availability_warning_threshold * 1000 * 1000LL) {
             not_avai_warning++;
         }

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -149,6 +149,7 @@ DEFINE_int64(tera_master_stat_table_splitsize, 100, "default split size of stat 
 DEFINE_int32(tera_master_gc_period, 60000, "the period (in ms) for master gc");
 
 DEFINE_bool(tera_master_availability_check_enabled, true, "whether execute availability check");    // reload config safety
+DEFINE_bool(tera_master_availability_show_details_enabled, false, "whether show details of not-ready tablets"); // reload config safety
 DEFINE_int64(tera_master_not_available_threshold, 0, "the threshold (in s) of not available");     // reload config safety
 DEFINE_int64(tera_master_availability_check_period, 60, "the period (in s) of availability check"); // reload config safety
 DEFINE_int64(tera_master_availability_warning_threshold, 30, "30s, the threshold (in s) of warning availability"); // reload config safety


### PR DESCRIPTION
#780 
通过一个flag控制是否打印出长时间not-ready的tablet信息。

例如存在这样一个需求场景：
系统在升级时，每时每刻都有部分（几十、几百甚至更多）tablet处于not-ready状态，
正常情况下每个tablet在几秒或更长时间之后就会ready起来，
但可能存在几个tablet异常一直load不起来，但它们混在整个集群中看不粗来！因为每时每刻都有好多not-ready的tablet，分不出来哪些是一直not-ready的。

这个功能也可以用于排查其它问题。