### PR TITLE
issue=#811 teracli-output-op-friendly

### DIFF
--- a/src/utils/tprinter.cc
+++ b/src/utils/tprinter.cc
@@ -118,17 +118,21 @@ string TPrinter::ToString(const PrintOpt& opt) {
         }
         ostr << std::endl;
     }
-
+    bool first_line = true;
     for (size_t i = 0; i < body_.size(); ++i) {
         std::vector<string> line;
         FormatOneLine(body_[i], &line);
+        if (first_line) {
+            first_line = false;
+        } else {
+            ostr << std::endl;
+        }
         for (int j = 0; j < cols_; ++j) {
             ostr << "  " << std::setfill(' ')
                 << std::setw(col_width_[j])
                 << std::setiosflags(std::ios::left)
                 << line[j];
         }
-        ostr << std::endl;
     }
     return ostr.str();
 }


### PR DESCRIPTION
#811 

问题：teracli输出对运维、脚本不友好，有些场景下需要标准的矩阵输出（不要标题栏、不要各种分解符、多余的换行、空行等），以便用户解析teracli的输出。