### PR TITLE
issue=#462 Python-SDK.Specifying the required argument types

### DIFF
--- a/src/sdk/python/TeraSdk.py
+++ b/src/sdk/python/TeraSdk.py
@@ -824,6 +824,9 @@ def init_function_prototype():
                                         POINTER(c_char_p)]
     lib.tera_table_putint64.restype = c_bool
 
+    lib.tera_table_scan.argtypes = [c_void_p, c_void_p, POINTER(c_char_p)]
+    lib.tera_table_scan.restype = c_void_p
+
     lib.tera_table_delete.argtypes = [c_void_p, c_char_p, c_uint64,
                                       c_char_p, c_char_p, c_uint64]
     lib.tera_table_delete.restype = None


### PR DESCRIPTION
#462 

指定python-ctypes调用libc.so时函数参数的类型，协调二者兼容。

否则python-ctypes传给C的和C从栈上拿到并解释的数据不一致。