### PR TITLE
issue=#780 bugfix.availability-checker-abuses-gc-timer

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -5239,7 +5239,7 @@ void MasterImpl::ScheduleAvailableCheck() {
     m_mutex.AssertHeld();
     ThreadPool::Task task =
         boost::bind(&MasterImpl::DoAvailableCheck, this);
-    m_gc_timer_id = m_thread_pool->DelayTask(
+    m_thread_pool->DelayTask(
         FLAGS_tera_master_availability_check_period * 1000, task);
 }
 


### PR DESCRIPTION
#780

可用性检查是一个定时任务，定时调度逻辑是从gc拷贝的，结果出了点错误：

（可用性检查定时任务）返回的timer-id被错误赋值给了 m_gc_timer_id.