### PR TITLE
issue=#811 bugfix.teracli.show-table-newline

### DIFF
--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -1381,6 +1381,7 @@ int32_t ShowSingleTable(Client* client, const string& table_name,
         std::cout << std::endl;
     }
     ShowTabletList(tablet_list, true, is_x);
+    std::cout << std::endl;
     return 0;
 }
 


### PR DESCRIPTION
#811 
之前把`std::cout << std::endl`给误删了，导致 `./teracli show <tablename>` 最后少一个换行，现在加上。