### PR TITLE
issue=#462 sdk-python.performance-improvement

### DIFF
--- a/src/sdk/python/TeraSdk.py
+++ b/src/sdk/python/TeraSdk.py
@@ -983,16 +983,17 @@ def init_function_prototype():
     lib.tera_row_reader_destroy.argtypes = [c_void_p]
     lib.tera_row_reader_destroy.restype = None
 
+    libc.free.argtypes = [c_void_p]
+    libc.free.restype = None
+
 
 def copy_string_to_user(value, size):
     result = string_at(value, size)
-    libc = cdll.LoadLibrary('libc.so.6')
-    libc.free.argtypes = [c_void_p]
-    libc.free.restype = None
     libc.free(value)
     return result
 
 
 lib = cdll.LoadLibrary('./libtera_c.so')
+libc = cdll.LoadLibrary('libc.so.6')
 
 init_function_prototype()


### PR DESCRIPTION
#462 

经测试，scan吞吐性能提高3倍。

更新后的python-sdk的scan吞吐性能为C++-sdk的 1/4 ~ 1/3.

读性能也会受益很大，具体数据未测试。

当然，diff 前的版本是某次脑残写成这样的。。