### PR TITLE
issue=#811 teracli.debugstring-on-binary

### DIFF
--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -61,6 +61,8 @@ DEFINE_int32(concurrency, 1, "concurrency for compact table.");
 DEFINE_int64(timestamp, -1, "timestamp.");
 DEFINE_string(tablets_file, "", "tablet set file");
 
+DEFINE_bool(printable, true, "printable output");
+
 // using FLAGS instead of isatty() for compatibility
 DEFINE_bool(stdout_is_tty, true, "is stdout connected to a tty");
 DEFINE_bool(reorder_tablets, false, "reorder tablets by ts list");
@@ -843,6 +845,14 @@ int32_t GetInt64Op(Client* client, int32_t argc, char** argv, ErrorCode* err) {
     return 0;
 }
 
+std::string PrintableFormatter(const std::string& value) {
+    if (FLAGS_printable) {
+        return DebugString(value);
+    } else {
+        return value;
+    }
+}
+
 int32_t GetOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
     if (argc != 4 && argc != 5) {
         LOG(ERROR) << "args number error: " << argc << ", need 5 | 6.";
@@ -875,10 +885,10 @@ int32_t GetOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
     }
     table->Get(reader);
     while (!reader->Done()) {
-        std::cout << reader->RowName() << ":"
-           << reader->ColumnName() << ":"
-           << reader->Timestamp() << ":"
-           << reader->Value() << std::endl;
+        std::cout << PrintableFormatter(reader->RowName()) << ":"
+            << PrintableFormatter(reader->ColumnName()) << ":"
+            << reader->Timestamp() << ":"
+            << PrintableFormatter(reader->Value()) << std::endl;
         reader->Next();
     }
     delete reader;
@@ -1001,10 +1011,11 @@ int32_t ScanRange(TablePtr& table, ScanDescriptor& desc, ErrorCode* err) {
         g_total_size += len;
         g_key_num ++;
         g_cur_batch_num ++;
-        std::cout << result_stream->RowName() << ":"
-           << result_stream->ColumnName() << ":"
-           << result_stream->Timestamp() << ":"
-           << result_stream->Value() << std::endl;
+        std::cout << PrintableFormatter(result_stream->RowName()) << ":"
+            << PrintableFormatter(result_stream->ColumnName()) << ":"
+            << result_stream->Timestamp() << ":"
+            << PrintableFormatter(result_stream->Value()) << std::endl;
+
         result_stream->Next();
         if (g_cur_batch_num >= FLAGS_tera_client_batch_put_num) {
             int32_t time_cur=time(NULL);


### PR DESCRIPTION
#811 

给teracli加个选项，在输出的时候将二进制数据打印为debugstring.

用法：
```
./teracli get oops row123 cf0:qu0    # 默认打印debugstring过的数据

./teracli get oops row123 cf0:qu0 --noprintable    # 需要原始数据
```

有个问题，为了代码看起来简洁点，我实现了一个PrintableFormatter()函数，代价是：即便不是二进制，也会有一次额外的字符串拷贝（value原样返回）。
现在是这样的：
```
std::cout << result_stream->RowName() << ":"
    << result_stream->ColumnName() << ":"
    << result_stream->Timestamp() << ":"
    << PrintableFormatter(result_stream->Value()) << std::endl;
```

有个效率更高的方法，形如
```        
    std::cout << reader->RowName() << ":"
        << reader->ColumnName() << ":"
        << reader->Timestamp() << ":";
    if (FLAGS_printable) {
        std::cout << DebugString(reader->Value()) << std::endl;
    } else {
        std::cout << reader->Value() << std::endl;
    }
```
我想了下，反正瓶颈一般也不在teracli，所以干脆选看起来实现更简洁的一个（前者）。。。

求建议。