### PR TITLE
issue=#462 bugfix.tera_c-lock

### DIFF
--- a/src/tera_c.cc
+++ b/src/tera_c.cc
@@ -232,12 +232,11 @@ void tera_row_reader_callback_stub(RowReader* reader) {
     void* c_reader = apair.first; // C tera_row_reader_t*
     ReaderCallbackType callback = (ReaderCallbackType)apair.second;
 
+    g_reader_callback_map.erase(it);
     g_reader_mutex.Unlock();
     // users use C tera_row_reader_t* to construct it's own object
     callback(c_reader);
     g_reader_mutex.Lock();
-
-    g_reader_callback_map.erase(it);
 }
 
 void tera_row_reader_set_callback(tera_row_reader_t* reader, ReaderCallbackType callback) {
@@ -345,12 +344,11 @@ void tera_row_mutation_callback_stub(RowMutation* mu) {
     void* c_mu = apair.first; // C tera_row_mutation_t*
     MutationCallbackType callback = (MutationCallbackType)apair.second;
 
+    g_mutation_callback_map.erase(it);
     g_mutation_mutex.Unlock();
     // users use C tera_row_mutation_t* to construct it's own object
     callback(c_mu);
     g_mutation_mutex.Lock();
-
-    g_mutation_callback_map.erase(it);
 }
 
 void tera_row_mutation_set_callback(tera_row_mutation_t* mu, MutationCallbackType callback) {


### PR DESCRIPTION
#462 

<img width="564" alt="screen shot 2016-07-26 at 19 04 56" src="https://cloud.githubusercontent.com/assets/5194281/17135756/e1e848b2-5363-11e6-831f-8a804914f842.png">

存在时序问题。

如图，如代码。

有个map的key是new RowReader得到的指针。

time-0时刻，线程a 释放mutex执行用户回调
time-1时刻，线程a 在回调中delete掉这个RowReader 0x123
time-2时刻，线程b 可能在new RowReader时分配到相同的地址（0x123）并insert到这个map里（失败但并没有检查，没有检查是因为理论上不会失败。。）
time-3时刻，线程a 执行完回调重新拿到mutex，然后从map里把（0x123） erase掉。（线程b 下次再去查找0x123时就失败了）
