### PR TITLE
sql: support 'order by' of select stmt

### DIFF
--- a/sql/src/ha_tera.h
+++ b/sql/src/ha_tera.h
@@ -104,12 +104,9 @@ public:
   */
   ulonglong table_flags() const
   {
-    /*
-      We are saying that this engine is just statement capable to have
-      an engine that can only handle statement-based logging. This is
-      used in testing.
-    */
-    return HA_BINLOG_STMT_CAPABLE;
+    return HA_NO_TRANSACTIONS |  // not support txn
+           HA_REC_NOT_IN_SEQ |   // support 'sort by', through position() and rnd_pos()
+           HA_BINLOG_STMT_CAPABLE;
   }
 
   /** @brief

--- a/sql/src/ha_tera_util.cc
+++ b/sql/src/ha_tera_util.cc
@@ -84,3 +84,17 @@ bool ha_tera_util::tera_tabname_to_name(const char* tera_tabname, char* dbname, 
   return true;
 }
 
+std::string escape_string(const std::string& src) {
+    std::string dst;
+    for (size_t i = 0; i < src.size(); i++) {
+        char c = src[i];
+        if (c >= ' ' && c <= '~') {
+            dst.push_back(c);
+        } else {
+            char buf[10];
+            snprintf(buf, sizeof(buf), "\\x%02x", static_cast<unsigned int>(c) & 0xff);
+            dst.append(buf);
+        }
+    }
+    return dst;
+}

--- a/sql/src/ha_tera_util.h
+++ b/sql/src/ha_tera_util.h
@@ -17,6 +17,8 @@
   along with this program; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
+#include <string>
+
 class ha_tera_util {
 public:
   static void path_to_dbname(const char *path_name, char *dbname);
@@ -24,3 +26,5 @@ public:
   static void name_to_tera_tabname(const char* dbname, const char* tabname, char* tera_tabname);
   static bool tera_tabname_to_name(const char* tera_tabname, char* dbname, char* tabname);
 };
+
+std::string escape_string(const std::string& src);


### PR DESCRIPTION
select * from table order by id; 
执行过程：

调用函数 | 含义 | 举例
--------|-----------|---
rnd_init() | it = new Iterator | 
rnd_next() | it->next(); return it->key() | id: 9
position() | pos1 = it->key() | 
rnd_next() | it->next(); return it->key() | id: 3
position() | pos2 = it->key() | 
... | ...
rnd_next() | it->next(); return it->key() | id: 6
position() | posN = it->key() | 
... | ...
sort_keys() | 排序所有key
... | ...
rnd_pos() | it->seek(pos2); return it->key() | id: 3
rnd_pos() | it->seek(posN); return it->key() | id: 6
rnd_pos() | it->seek(pos1); return it->key() | id: 9
...|...
