### PR TITLE
issue=#936 bugfix.threadpool_delay_1ms

### DIFF
--- a/src/common/mutex.h
+++ b/src/common/mutex.h
@@ -131,13 +131,13 @@ public:
         PthreadCall("condvar wait", pthread_cond_wait(&cond_, &mu_->mu_));
         mu_->AfterLock(msg, msg_threshold);
     }
-    // Time wait in ms
+    // Time wait in us
     // timeout < 0 would cause ETIMEOUT and return false immediately
-    bool TimeWait(int timeout, const char* msg = NULL) {
+    bool TimeWaitInUs(int timeout, const char* msg = NULL) {
         timespec ts;
         struct timeval tv;
         gettimeofday(&tv, NULL);
-        int64_t usec = tv.tv_usec + timeout * 1000LL;
+        int64_t usec = tv.tv_usec + timeout;
         ts.tv_sec = tv.tv_sec + usec / 1000000;
         ts.tv_nsec = (usec % 1000000) * 1000;
         int64_t msg_threshold = mu_->msg_threshold_;
@@ -145,6 +145,11 @@ public:
         int ret = pthread_cond_timedwait(&cond_, &mu_->mu_, &ts);
         mu_->AfterLock(msg, msg_threshold);
         return (ret == 0);
+    }
+    // Time wait in ms
+    // timeout < 0 would cause ETIMEOUT and return false immediately
+    bool TimeWait(int timeout, const char* msg = NULL) {
+        return TimeWaitInUs(timeout * 1000LL, msg);
     }
     void Signal() {
         PthreadCall("signal", pthread_cond_signal(&cond_));

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -188,7 +188,7 @@ private:
             if (!time_queue_.empty()) {
                 int64_t now_time = timer::get_micros();
                 BGItem bg_item = time_queue_.top();
-                int64_t wait_time = (bg_item.exe_time - now_time) / 1000; // in ms
+                int64_t wait_time = bg_item.exe_time - now_time; // in us
                 if (wait_time <= 0) {
                     time_queue_.pop();
                     BGMap::iterator it = latest_.find(bg_item.id);
@@ -207,7 +207,7 @@ private:
                     }
                     continue;
                 } else if (queue_.empty() && !stop_) {
-                    work_cv_.TimeWait(wait_time, "ThreadProcTimeWait");
+                    work_cv_.TimeWaitInUs(wait_time, "ThreadProcTimeWait");
                     continue;
                 }
             }


### PR DESCRIPTION
#936 
如 ` src/common/thread_pool.h` 191 行
wait_time 原单位为 ms；如果用户定时任务为1ms，wait_time 很容易因为不到1ms（很可能是几个、几十个us） 除以1000 而变成 0 。导致原本1ms的定时任务只隔了几个、几十个us就执行一次，从而定时1ms的任务会执行得比预期快几十、几百倍。

这个问题导致sdk里1ms的任务执行太快占用cpu很高。