### PR TITLE
issue=#982 bugfix.nexus-session-id

### DIFF
--- a/src/tabletnode/tabletnode_zk_adapter.cc
+++ b/src/tabletnode/tabletnode_zk_adapter.cc
@@ -363,14 +363,15 @@ void InsTabletNodeZkAdapter::Init() {
     // create session
     m_ins_sdk = new galaxy::ins::sdk::InsSDK(FLAGS_tera_ins_addr_list);
 
-    // get session id
-    std::string session_id = m_ins_sdk->GetSessionID();
-    m_tabletnode_impl->SetSessionId(session_id);
-    m_tabletnode_impl->SetTabletNodeStatus(TabletNodeImpl::kIsRunning);
-
     // create node
     std::string lock_key = root_path + kTsListPath + "/" + m_server_addr;
     CHECK(m_ins_sdk->Lock(lock_key, &err)) << "register fail";
+
+    // get session id
+    // session-id may be changed during Lock(), so we must be call Lock() first, and then get the session-id.
+    std::string session_id = m_ins_sdk->GetSessionID();
+    m_tabletnode_impl->SetSessionId(session_id);
+    m_tabletnode_impl->SetTabletNodeStatus(TabletNodeImpl::kIsRunning);
     LOG(INFO) << "create ts-node success: " << session_id;
 
     // create watch node


### PR DESCRIPTION
#982  



ts初始化时，是先get session-id，再去lock。

问题在于lock返回时，session-id可能已经变了（例如lock内有超时重试），但ts还用着旧的session-id。
导致ts实际的session-id和它自以为的session-id不一致，引发后续诸多问题。