### PR TITLE
issue=#995 bugfix.ttlkv-scan

### DIFF
--- a/src/io/tablet_io.cc
+++ b/src/io/tablet_io.cc
@@ -1521,7 +1521,12 @@ bool TabletIO::Scan(const ScanOption& option, KeyValueList* kv_list,
     for (; it->Valid(); it->Next()) {
         leveldb::Slice key = it->key();
         leveldb::Slice value = it->value();
-        *complete = (!noexist_end && key_operator_->Compare(key, end) >= 0);
+        if (RawKeyType() == TTLKv) {
+            // only compare row key
+            *complete = (!noexist_end && key_operator_->Compare(key, end) >= 0);
+        } else {
+            *complete = (!noexist_end && key.compare(end) >= 0);
+        }
         if (*complete || (option.size_limit() > 0 && pack_size > option.size_limit())) {
             break;
         } else {

--- a/src/leveldb/util/raw_key_operator.cc
+++ b/src/leveldb/util/raw_key_operator.cc
@@ -263,17 +263,9 @@ public:
 
     // only compare row_key
     virtual int Compare(const Slice& key1, const Slice& key2) const {
-        size_t min_len = (key1.size() < key2.size()) ? key1.size() : key2.size();
-        int r = memcmp(key1.data(), key2.data(), min_len);
-        if (r == 0) {
-            if (key1.size() < key2.size()) {
-                r = -1;
-            }
-            else if (key1.size() > key2.size()) {
-                r = +1;
-            }
-        }
-        return r;
+        leveldb::Slice key1_rowkey(key1.data(), key1.size() - sizeof(int64_t));
+        leveldb::Slice key2_rowkey(key2.data(), key2.size() - sizeof(int64_t));
+        return key1_rowkey.compare(key2_rowkey);
     }
 };
 


### PR DESCRIPTION
#995 

当前KV和TTLKV公用`KvRawKeyOperatorImpl`，但`KvRawKeyOperatorImpl`的`Compare()`实现不支持ttlkv的rowkey比较，造成ttlkv表scan出的结果会少数据。

复现方法：（ttlkv表）
假设库中有数据：
```
a:va
b:vb
z:vz
```

`./teracli scan table_name a bz`

预期的结果是：
```
a:va
b:vb
```

实际结果：
`
a:va
`

**如代码所示**，当leveldb迭代到 key == b 时，(TTLKV里，ttl拼在rowkey后面）
end = 'bz\x00\x00\x00\x00\x00\x00\x00\x00'
key  = 'b\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'

此时应该只对rowkey进行比较，既 'b' 和 'bz'；
但之前的实现带上了ttl，误以为已经scan到了终止位置，提前结束少了数据。
