### PR TITLE
issue=#962 master.tablet-updatetime-init-with-current-time

### DIFF
--- a/src/master/tablet_manager.cc
+++ b/src/master/tablet_manager.cc
@@ -17,6 +17,7 @@
 #include "common/base/string_format.h"
 #include "common/base/string_number.h"
 #include "common/file/file_path.h"
+#include "common/timer.h"
 #include "db/filename.h"
 #include "io/io_utils.h"
 #include "io/utils_leveldb.h"
@@ -59,13 +60,13 @@ std::ostream& operator << (std::ostream& o, const TabletPtr& tablet) {
 
 Tablet::Tablet(const TabletMeta& meta)
     : meta_(meta),
-      update_time_(0),
+      update_time_(common::timer::get_micros()),
       load_time_(std::numeric_limits<int64_t>::max()) {}
 
 Tablet::Tablet(const TabletMeta& meta, TablePtr table)
     : meta_(meta),
       table_(table),
-      update_time_(0),
+      update_time_(common::timer::get_micros()),
       load_time_(std::numeric_limits<int64_t>::max()) {}
 
 Tablet::~Tablet() {


### PR DESCRIPTION
#962 

有外部监控系统会定期查看各个tablet的状态，例如每个tablet的更新时间（每次query都会更新），如果长时间不更新则可能出了故障会报警。

如代码diff，原实现中，新生成的tablet更新时间默认为0，导致tablet刚生成时，如果监控系统恰巧来检测，就会被误认为巨久没有更新，导致大量的误报，严重干扰日常运维工作。

已经过测试。