### PR TITLE
issue=#393 master.separate-admin-and-readonly-permissions

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -1131,19 +1131,11 @@ void MasterImpl::ShowTables(const ShowTablesRequest* request,
         TableMetaList* table_meta_list = response->mutable_table_meta_list();
         for (uint32_t i = 0; i < table_list.size(); ++i) {
             TablePtr table = table_list[i];
-            // if a user has NO permission on a table,
-            // he/she should not notice this table
-            if (!HasPermissionOnTable(request, table)) {
-                continue;
-            }
             CopyTableMetaToUser(table, table_meta_list->add_meta());
         }
         TabletMetaList* tablet_meta_list = response->mutable_tablet_meta_list();
         for (uint32_t i = 0; i < tablet_list.size(); ++i) {
             TabletPtr tablet = tablet_list[i];
-            if (!HasPermissionOnTable(request, tablet->GetTable())) {
-                continue;
-            }
             TabletMeta meta;
             tablet->ToMeta(&meta);
             tablet_meta_list->add_meta()->CopyFrom(meta);
@@ -1179,11 +1171,6 @@ void MasterImpl::ShowTablesBrief(const ShowTablesRequest* request,
     TableMetaList* table_meta_list = response->mutable_table_meta_list();
     for (uint32_t i = 0; i < table_list.size(); ++i) {
         TablePtr table = table_list[i];
-        // if a user has NO permission on a table,
-        // he/she should not notice this table
-        if (!HasPermissionOnTable(request, table)) {
-            continue;
-        }
         table->ToMeta(table_meta_list->add_meta());
         table_meta_list->add_counter()->CopyFrom(table->GetCounter());
     }
@@ -1227,9 +1214,6 @@ void MasterImpl::ShowTabletNodes(const ShowTabletNodesRequest* request,
         std::vector<TabletPtr> tablet_list;
         tablet_manager_->FindTablet(request->addr(), &tablet_list);
         for (size_t i = 0; i < tablet_list.size(); ++i) {
-            if (!HasPermissionOnTable(request, tablet_list[i]->GetTable())) {
-                continue;
-            }
             TabletMeta* meta = response->mutable_tabletmeta_list()->add_meta();
             TabletCounter* counter = response->mutable_tabletmeta_list()->add_counter();
             tablet_list[i]->ToMeta(meta);


### PR DESCRIPTION
#393 

之前是将“管理权限“与”读权限“放在一起的。导致的问题：一个用户，要么有某个表的全部权限，要么啥权限都没有，show的时候也看不到对应表格。

现在拆开，默认任何人都能show出结果来。
这样我们可以更新现有的集群，既能防止用户肆意更改表格schema，又不妨碍ta们查看当前状态。

读元信息的权限，有需要时再实现。