### PR TITLE
issue=#18 ins/nexus version bump to 0.14

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,18 +195,18 @@ if [ ! -f "${FLAG_DIR}/gperftools_2_2_1" ] \
 fi
 
 # ins
-if [ ! -f "${FLAG_DIR}/ins_0_13" ] \
+if [ ! -f "${FLAG_DIR}/ins_0_14" ] \
     || [ ! -f "${DEPS_PREFIX}/lib/libins_sdk.a" ] \
     || [ ! -f "${DEPS_PREFIX}/include/ins_sdk.h" ]; then
-    wget --no-check-certificate -O ins-0.13.tar.gz https://github.com/baidu/ins/archive/0.13.tar.gz
-    tar zxf ins-0.13.tar.gz
-    cd ins-0.13
+    wget --no-check-certificate -O ins-0.14.tar.gz https://github.com/baidu/ins/archive/0.14.tar.gz
+    tar zxf ins-0.14.tar.gz
+    cd ins-0.14
     sed -i "s|^PREFIX=.*|PREFIX=${DEPS_PREFIX}|" Makefile
     sed -i "s|^PROTOC=.*|PROTOC=${DEPS_PREFIX}/bin/protoc|" Makefile
     BOOST_PATH=${DEPS_PREFIX}/boost_1_58_0 make install_sdk
     make -j4 install_sdk
     cd -
-    touch "${FLAG_DIR}/ins_0_13"
+    touch "${FLAG_DIR}/ins_0_14"
 fi
 
 cd ${WORK_DIR}

--- a/internal_build.sh
+++ b/internal_build.sh
@@ -72,7 +72,7 @@ if [ ! -f "${FLAG_DIR}/sofa-pbrpc_1_1_0" ] \
     sed -i '/BOOST_HEADER_DIR=/ d' depends.mk
     sed -i '/PROTOBUF_DIR=/ d' depends.mk
     sed -i '/SNAPPY_DIR=/ d' depends.mk
-    echo "BOOST_HEADER_DIR=${DEPS_PREFIX}/boost_1_57_0" >> depends.mk
+    echo "BOOST_HEADER_DIR=${DEPS_PREFIX}/boost_1_58_0" >> depends.mk
     echo "PROTOBUF_DIR=${DEPS_PREFIX}" >> depends.mk
     echo "SNAPPY_DIR=${DEPS_PREFIX}" >> depends.mk
     echo "PREFIX=${DEPS_PREFIX}" >> depends.mk
@@ -179,16 +179,16 @@ if [ ! -f "${FLAG_DIR}/gperftools_2_2_1" ] \
 fi
 
 # ins
-if [ ! -f "${FLAG_DIR}/ins_0_13" ] \
+if [ ! -f "${FLAG_DIR}/ins_0_14" ] \
     || [ ! -f "${DEPS_PREFIX}/lib/libins_sdk.a" ] \
     || [ ! -f "${DEPS_PREFIX}/include/ins_sdk.h" ]; then
-    tar zxf ins-0.13.tar.gz
-    cd ins-0.13
+    tar zxf ins-0.14.tar.gz
+    cd ins-0.14
     sed -i "s|^PREFIX=.*|PREFIX=${DEPS_PREFIX}|" Makefile
     sed -i "s|^PROTOC=.*|PROTOC=${DEPS_PREFIX}/bin/protoc|" Makefile
-    BOOST_PATH=${DEPS_PREFIX}/boost_1_57_0 make -j4 install_sdk
+    BOOST_PATH=${DEPS_PREFIX}/boost_1_58_0 make -j4 install_sdk
     cd -
-    touch "${FLAG_DIR}/ins_0_13"
+    touch "${FLAG_DIR}/ins_0_14"
 fi
 
 # functional test: nose


### PR DESCRIPTION
#18

当前依赖的ins/nexus sdk 0.13版本过旧，有高危漏洞，
例如ts掉锁以后自己不知道，会一直活着，导致多load.

nexus sdk在0.14版本中已修复该问题。