### PR TITLE
hide dfs.so' symbol

### DIFF
--- a/src/leveldb/util/nfs.cc
+++ b/src/leveldb/util/nfs.cc
@@ -64,7 +64,7 @@ void* ResolveSymbol(void* dl, const char* sym) {
 
 void Nfs::LoadSymbol() {
   dlerror();
-  void* dl = dlopen("libnfs.so", RTLD_NOW | RTLD_GLOBAL);
+  void* dl = dlopen("libnfs.so", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
   if (dl == NULL) {
     fprintf(stderr, "dlopen libnfs.so error: %s\n", dlerror());
     abort();


### PR DESCRIPTION
升级nfs.so是发现的gflags符号冲突，通过隐藏so的符号解决。