### PR TITLE
issue=#1071 bugfix.sdk-delete-row

### DIFF
--- a/src/sdk/mutate_impl.cc
+++ b/src/sdk/mutate_impl.cc
@@ -258,7 +258,11 @@ void RowMutationImpl::DeleteFamily(const std::string& family,
 void RowMutationImpl::DeleteRow(int64_t timestamp) {
     RowMutation::Mutation& mutation = AddMutation();
     mutation.type = RowMutation::kDeleteRow;
-    mutation.timestamp = timestamp;
+    if (timestamp == -1) {
+        mutation.timestamp = kLatestTimestamp;
+    } else {
+        mutation.timestamp = timestamp;
+    }
 }
 
 /// 修改锁住的行, 必须提供行锁

--- a/test/testcase/test_model_limit.py
+++ b/test/testcase/test_model_limit.py
@@ -30,9 +30,9 @@ def setUp():
 def tearDown():
     pass
 
-    '''
-    64KB rowkey
-    '''
+'''
+64KB rowkey
+'''
 def test_rowkey_size_0():
 
     try:
@@ -42,18 +42,18 @@ def test_rowkey_size_0():
         return
     nose.tools.assert_true(False)
 
-    '''
-    64KB - 1 rowkey
-    '''
+'''
+64KB - 1 rowkey
+'''
 def test_rowkey_size_1():
 
     table.Put("a" * (64 * 1024 - 1), "cf0", "qu0", "value_0")
     nose.tools.assert_equal(table.Get("a" * (64 * 1024 - 1), "cf0", "qu0", 0),
                             "value_0")
 
-    '''
-    64KB qualifier
-    '''
+'''
+64KB qualifier
+'''
 def test_qualifier_size_0():
 
     try:
@@ -63,18 +63,18 @@ def test_qualifier_size_0():
         return
     nose.tools.assert_true(False)
 
-    '''
-    64KB - 1 qualifier
-    '''
+'''
+64KB - 1 qualifier
+'''
 def test_qualifier_size_1():
 
     table.Put("row_qu_size", "cf0", "b" * (64 * 1024 - 1), "value_0")
     nose.tools.assert_equal(table.Get("row_qu_size", "cf0", "b" * (64 * 1024 - 1), 0),
                             "value_0")
 
-    '''
-    32MB value
-    '''
+'''
+32MB value
+'''
 def test_value_size_0():
 
     try:
@@ -84,9 +84,9 @@ def test_value_size_0():
         return
     nose.tools.assert_true(False)
 
-    '''
-    32MB - 1 value
-    '''
+'''
+32MB - 1 value
+'''
 def test_value_size_1():
 
     table.Put("row_qu_size", "cf0", "qu0", "v" * (32 * 1024 * 1024 - 1))

--- a/test/testcase/test_write_read_update_delete.py
+++ b/test/testcase/test_write_read_update_delete.py
@@ -1,0 +1,54 @@
+'''
+Copyright (c) 2016, Baidu.com, Inc. All Rights Reserved
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+'''
+
+import common
+import nose.tools
+from TeraSdk import Client, TeraSdkException
+
+
+table = None
+
+def setUp():
+    #clear env
+    common.drop_table("crud_table")
+
+    #set env
+    cmd = "./teracli create 'crud_table{lg0{cf0}}'"
+    common.exe_and_check_res(cmd)
+    global table
+    try:
+        client = Client("", "pysdk")
+        table = client.OpenTable("crud_table")
+    except TeraSdkException as e:
+        print(e.reason)
+        nose.tools.assert_true(False)
+
+def tearDown():
+    pass
+
+'''
+0. put
+1. read
+2. delete row
+3. read
+4. put
+5. read
+'''
+def test_case_0():
+    table.Put("row", "cf0", "qu0", "value")
+    nose.tools.assert_equal(table.Get("row", "cf0", "qu0", 0), "value")
+
+    mu = table.NewRowMutation("row")
+    mu.DeleteRow()
+    table.ApplyMutation(mu)
+
+    try:
+        table.Get("row", "cf0", "qu0", 0)
+    except TeraSdkException as e:
+        nose.tools.assert_true("not found" in e.reason)
+
+    table.Put("row", "cf0", "qu0", "value")
+    nose.tools.assert_equal(table.Get("row", "cf0", "qu0", 0), "value")


### PR DESCRIPTION
#1071 

once a row was deleted(delete-row), sequentially `write` cannot be seen.
reason: a row-delete-mark maybe with a large timestamp(bug), this mark would mask sequentially `write`.

一旦某一行被删除（行删除操作），后续的`write`都读不出来。
原因：行删除标记因为bug的原因可能会带上一个巨大的时间戳，导致这个时间戳会屏蔽后续的写入。