### PR TITLE
issue=#1095 bugfix_findtablet_for_ts

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -1200,7 +1200,9 @@ void MasterImpl::ShowTabletNodes(const ShowTabletNodesRequest* request,
         }
         response->add_tabletnode_info()->CopyFrom(tabletnode->GetInfo());
         std::vector<TabletPtr> tablet_list;
-        tablet_manager_->FindTablet(request->addr(), &tablet_list);
+        tablet_manager_->FindTablet(request->addr(),
+                                    &tablet_list,
+                                    false);  // don't need disabled tables/tablets
         for (size_t i = 0; i < tablet_list.size(); ++i) {
             TabletMeta* meta = response->mutable_tabletmeta_list()->add_meta();
             TabletCounter* counter = response->mutable_tabletmeta_list()->add_counter();
@@ -2118,7 +2120,9 @@ void MasterImpl::TabletNodeRecoveryCallback(std::string addr,
 
     // load offline tablets
     std::vector<TabletPtr> tablet_list;
-    tablet_manager_->FindTablet(addr, &tablet_list);
+    tablet_manager_->FindTablet(addr,
+                                &tablet_list,
+                                true);  // need disabled table/tablets
     std::vector<TabletPtr>::iterator it = tablet_list.begin();
     for (; it != tablet_list.end(); ++it) {
         TabletPtr tablet = *it;
@@ -2149,7 +2153,9 @@ void MasterImpl::DeleteTabletNode(const std::string& tabletnode_addr) {
 
     // move all tablets on the deleted tabletnode
     std::vector<TabletPtr> tablet_list;
-    tablet_manager_->FindTablet(tabletnode_addr, &tablet_list, true);
+    tablet_manager_->FindTablet(tabletnode_addr,
+                                &tablet_list,
+                                true);  // need disabled tables/tablets
     std::vector<TabletPtr>::iterator it;
     for (it = tablet_list.begin(); it != tablet_list.end(); ++it) {
         TabletPtr tablet = *it;
@@ -2200,7 +2206,9 @@ void MasterImpl::DeleteTabletNode(const std::string& tabletnode_addr) {
 
 void MasterImpl::TryMovePendingTablets(std::string tabletnode_addr) {
     std::vector<TabletPtr> tablet_list;
-    tablet_manager_->FindTablet(tabletnode_addr, &tablet_list);
+    tablet_manager_->FindTablet(tabletnode_addr,
+                                &tablet_list,
+                                true);  // need disabled tables/tablets
     std::vector<TabletPtr>::const_iterator it;
     for (it = tablet_list.begin(); it != tablet_list.end(); ++it) {
         TabletPtr tablet = *it;
@@ -3495,7 +3503,9 @@ void MasterImpl::QueryTabletNodeCallback(std::string addr, QueryRequest* request
         // calculate data_size of tabletnode
         // count both Ready/OnLoad and OffLine tablet
         std::vector<TabletPtr> tablet_list;
-        tablet_manager_->FindTablet(addr, &tablet_list);
+        tablet_manager_->FindTablet(addr,
+                                    &tablet_list,
+                                    false);  // don't need disabled tables/tablets
         std::vector<TabletPtr>::iterator it;
         for (it = tablet_list.begin(); it != tablet_list.end(); ++it) {
             TabletPtr tablet = *it;

--- a/src/master/tablet_manager.cc
+++ b/src/master/tablet_manager.cc
@@ -1122,13 +1122,13 @@ bool TabletManager::FindTablet(const std::string& table_name,
 
 void TabletManager::FindTablet(const std::string& server_addr,
                                std::vector<TabletPtr>* tablet_meta_list,
-                               bool all_tables) {
+                               bool need_disabled_tables) {
     mutex_.Lock();
     TableList::iterator it = all_tables_.begin();
     for (; it != all_tables_.end(); ++it) {
         Table& table = *it->second;
         table.mutex_.Lock();
-        if (table.status_ == kTableDisable && !all_tables) {
+        if (table.status_ == kTableDisable && !need_disabled_tables) {
             VLOG(10) << "FindTablet skip disable table: " << table.name_;
             table.mutex_.Unlock();
             continue;

--- a/src/master/tablet_manager.h
+++ b/src/master/tablet_manager.h
@@ -281,7 +281,7 @@ public:
 
     void FindTablet(const std::string& server_addr,
                     std::vector<TabletPtr>* tablet_meta_list,
-                    bool all_tables = false);
+                    bool need_disabled_tables);
 
     bool FindTable(const std::string& table_name,
                    std::vector<TabletPtr>* tablet_meta_list,


### PR DESCRIPTION
#1095

`src/master/master_impl.cc:2121L` the original implementation will not return the disabled table on the tabletserver, so, if the tabletserver resart(recovery) and the table is disabled, the tablet maybe pending forever