### PR TITLE
issue=1108, bugfix zk adapter, make master and tabletnode use same uuid

### DIFF
--- a/src/tabletnode/tabletnode_impl.cc
+++ b/src/tabletnode/tabletnode_impl.cc
@@ -221,7 +221,8 @@ void TabletNodeImpl::LoadTablet(const LoadTabletRequest* request,
     response->set_sequence_id(request->sequence_id());
     std::string sid = GetSessionId();
     if (!request->has_session_id() ||
-        request->session_id() != sid) {
+        (sid.size() == 0) ||
+        request->session_id().compare(0, sid.size(), sid) != 0) {
         LOG(WARNING) << "load session id not match: tablet " << request->path()
            << ", session_id " << request->session_id() << ", ts_id " << sid;
         response->set_status(kIllegalAccess);


### PR DESCRIPTION
make master and ts use session id as uuid to communicate with each other.