### PR TITLE
issue=#1129 force to unload and load on the same ts

### DIFF
--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -1453,7 +1453,13 @@ void MasterImpl::TabletCmdCtrl(const CmdCtrlRequest* request,
         return;
     }
 
-    if (request->arg_list(0) == "move") {
+    if (request->arg_list(0) == "reload") {
+        std::string current_server_addr = tablet->GetServerAddr();
+        TryMoveTablet(tablet,
+                      current_server_addr,
+                      true);  // force to unload and load tablet even it on the same ts
+
+    } else if (request->arg_list(0) == "move") {
         if (request->arg_list_size() > 3) {
             response->set_status(kInvalidArgument);
             return;
@@ -5052,8 +5058,8 @@ void MasterImpl::ResumeMetaOperation() {
     meta_task_mutex_.Unlock();
 }
 
-void MasterImpl::TryMoveTablet(TabletPtr tablet, const std::string& server_addr) {
-    if (tablet->GetServerAddr() == server_addr) {
+void MasterImpl::TryMoveTablet(TabletPtr tablet, const std::string& server_addr, bool in_place) {
+    if (!in_place && (tablet->GetServerAddr() == server_addr)) {
         return;
     }
     LOG(INFO) << "Move " << tablet << " from " << tablet->GetServerAddr()

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -249,7 +249,7 @@ private:
     void RetryUnloadTablet(TabletPtr tablet, int32_t retry_times);
     bool TrySplitTablet(TabletPtr tablet);
     bool TryMergeTablet(TabletPtr tablet);
-    void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "");
+    void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "", bool in_place = false);
 
     void TryReleaseCache(bool enbaled_debug = false);
     void ReleaseCacheWrapper();

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -229,6 +229,8 @@ const char* builtin_cmd_list[] = {
     "tablet",
     "tablet <operation> <params>                                          \n\
             move    <tablet_path> <target_addr>                           \n\
+            reload  <tablet_path>                                         \n\
+                    force to unload and load on the same ts               \n\
             compact <tablet_path>                                         \n\
             split   <tablet_path>                                         \n\
             merge   <tablet_path>                                         \n\
@@ -2335,7 +2337,7 @@ int32_t ScanTabletOp(Client* client, int32_t argc, char** argv, ErrorCode* err) 
 }
 
 int32_t TabletOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
-    if (argc != 4 && argc != 5) {
+    if ((argc != 4) && (argc != 5)) {
         PrintCmdHelpInfo(argv[1]);
         return -1;
     }
@@ -2346,7 +2348,7 @@ int32_t TabletOp(Client* client, int32_t argc, char** argv, ErrorCode* err) {
         return CompactTabletOp(client, argc, argv, err);
     } else if (op == "scan" || op == "scanallv") {
         return ScanTabletOp(client, argc, argv, err);
-    } else if (op != "move" && op != "split" && op != "merge") {
+    } else if (op != "move" && op != "split" && op != "merge" && op != "reload") {
         PrintCmdHelpInfo(argv[1]);
         return -1;
     }


### PR DESCRIPTION
#1129 

```
./teracli tablet reload <tablename>/tablet000xyz
```

形如这种命令，强制在原ts上unload然后load；
需要的场景：AI预测ts实例可能要挂了，通过此接口重新load其上的tablet，加速受影响tablet的恢复速度。

也可以用于人工干预。
