### PR TITLE
issue=#776 teracli create table delimiter file tips

### DIFF
--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -941,9 +941,15 @@ bool ParseDelimiterFile(const string& filename, std::vector<string>* delims) {
     bool is_delim_error = false;
     for (size_t i = 1; i < delimiters.size(); i++) {
         if (delimiters[i] <= delimiters[i-1]) {
-            LOG(ERROR) << "delimiter error: line: " << i + 1
-                << ", [" << delimiters[i] << "]";
+            LOG(ERROR) << "line[" << i << "]" << " SHOULD less than line[" << i + 1
+                << "] (bitwise comparison, maybe LC_ALL=C if you use command sort(1))";
+            LOG(ERROR) << "line[" << i << "]: (" << delimiters[i-1] << ")";
+            LOG(ERROR) << "line[" << i + 1 << "]: (" << delimiters[i] << ")";
             is_delim_error = true;
+            // just print the 1st invalid input case,
+            // if print all invalid input,
+            //   it will print too many log to read/understand
+            break;
         }
     }
     if (is_delim_error) {


### PR DESCRIPTION
#776 

建表时预分表，一般会有较多的区间。
如果预分表文件有问题（例如预期有序，但实际不是有序的），一般都会一股脑打印N多错误，实际使用时提示作用有效，反而有些干扰。

现在改成只打印遇到的第一个错误，方便用户查看具体问题；然后说明我们的比较规则（bitwise comparsion）；最后针对常见的错误和坑给一点提示（sort(1)用法错误导致）。

可以让teracli自动sort预分表文件，想了下sort(1)能很好地搞定这件事，还是交给sort(1)吧。而且自动容忍输入异常可能隐藏问题。