### PR TITLE
更改了一下 ExecuteCommand 和一个 HelpOp

### DIFF
--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -3275,16 +3275,14 @@ int ExecuteCommand(Client* client, int argc, char** arg_list) {
     if (!ParseCommand(argc, arg_list, &parsed_arg_list)) {
         return 1;
     }
-
     std::string* argv = &parsed_arg_list[0];
-    std::string cmd = argv[1];
 
     CommandTable_t& command_table = GetCommandTable();
-
+    std::string cmd = argv[1];
     if (cmd == "version") {
         PrintSystemVersion();
 	} else if (command_table.find(cmd) != command_table.end()) {
-        command_table[cmd](client, argc, argv, &error_code);
+        ret = command_table[cmd](client, argc, argv, &error_code);
     } else {
         PrintUnknownCmdHelpInfo(argv[1].c_str());
         ret = 1;

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -13,8 +13,8 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
-#include <sstream>
 #include <map>
+#include <sstream>
 
 #include <boost/shared_ptr.hpp>
 #include <gflags/gflags.h>
@@ -88,14 +88,14 @@ using namespace tera;
 
 typedef boost::shared_ptr<Table> TablePtr;
 typedef boost::shared_ptr<TableImpl> TableImplPtr;
-typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCode*)> CommandTable_t;
+typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCode*)> CommandTableT;
 
 /// global variables of single-row-txn used in interactive mode
 tera::Transaction* g_row_txn = NULL;
 Table* g_row_txn_table = NULL;
 
-static CommandTable_t& GetCommandTable(){
-    static CommandTable_t command_table;
+static CommandTableT& GetCommandTable(){
+    static CommandTableT command_table;
     return command_table;
 }
 
@@ -3196,7 +3196,7 @@ int32_t HelpOp(Client*, int32_t argc, std::string* argv, ErrorCode*) {
 }
 
 int32_t HelpOp(int32_t argc, char** argv) {
-	std::vector<std::string> argv_svec(argv, argv + argc);
+    std::vector<std::string> argv_svec(argv, argv + argc);
     return HelpOp(NULL, argc, &argv_svec[0], NULL);
 }
 
@@ -3213,7 +3213,7 @@ bool ParseCommand(int argc, char** arg_list, std::vector<std::string>* parsed_ar
 }
 
 static void InitializeCommandTable(){
-    CommandTable_t& command_table = GetCommandTable();
+    CommandTableT& command_table = GetCommandTable();
     command_table["create"] = CreateOp;
     command_table["createbyfile"] = CreateByFileOp;
     command_table["update"] = UpdateOp;
@@ -3264,7 +3264,7 @@ static void InitializeCommandTable(){
     command_table["range"] = RangeOp;
     command_table["rangex"] = RangeOp;
     command_table["txn"] = TxnOp;
-	command_table["help"] = HelpOp;
+    command_table["help"] = HelpOp;
 }
 
 int ExecuteCommand(Client* client, int argc, char** arg_list) {
@@ -3277,11 +3277,11 @@ int ExecuteCommand(Client* client, int argc, char** arg_list) {
     }
     std::string* argv = &parsed_arg_list[0];
 
-    CommandTable_t& command_table = GetCommandTable();
+    CommandTableT& command_table = GetCommandTable();
     std::string cmd = argv[1];
     if (cmd == "version") {
         PrintSystemVersion();
-	} else if (command_table.find(cmd) != command_table.end()) {
+    } else if (command_table.find(cmd) != command_table.end()) {
         ret = command_table[cmd](client, argc, argv, &error_code);
     } else {
         PrintUnknownCmdHelpInfo(argv[1].c_str());
@@ -3313,7 +3313,7 @@ int main(int argc, char* argv[]) {
     }
     g_printer_opt.print_head = FLAGS_stdout_is_tty;
 
-	InitializeCommandTable();
+    InitializeCommandTable();
 
     int ret  = 0;
     if (argc == 1) {

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -94,8 +94,8 @@ typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCo
 tera::Transaction* g_row_txn = NULL;
 Table* g_row_txn_table = NULL;
 
-static CommandTableT& GetCommandTable(){
-    static CommandTableT command_table;
+static CommandTable& GetCommandTable(){
+    static CommandTable command_table;
     return command_table;
 }
 
@@ -3213,7 +3213,7 @@ bool ParseCommand(int argc, char** arg_list, std::vector<std::string>* parsed_ar
 }
 
 static void InitializeCommandTable(){
-    CommandTableT& command_table = GetCommandTable();
+    CommandTable& command_table = GetCommandTable();
     command_table["create"] = CreateOp;
     command_table["createbyfile"] = CreateByFileOp;
     command_table["update"] = UpdateOp;
@@ -3277,7 +3277,7 @@ int ExecuteCommand(Client* client, int argc, char** arg_list) {
     }
     std::string* argv = &parsed_arg_list[0];
 
-    CommandTableT& command_table = GetCommandTable();
+    CommandTable& command_table = GetCommandTable();
     std::string cmd = argv[1];
     if (cmd == "version") {
         PrintSystemVersion();

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -88,7 +88,7 @@ using namespace tera;
 
 typedef boost::shared_ptr<Table> TablePtr;
 typedef boost::shared_ptr<TableImpl> TableImplPtr;
-typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCode*)> CommandTableT;
+typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCode*)> CommandTable;
 
 /// global variables of single-row-txn used in interactive mode
 tera::Transaction* g_row_txn = NULL;

--- a/src/teracli_main.cc
+++ b/src/teracli_main.cc
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <limits>
 #include <sstream>
+#include <map>
 
 #include <boost/shared_ptr.hpp>
 #include <gflags/gflags.h>
@@ -87,10 +88,16 @@ using namespace tera;
 
 typedef boost::shared_ptr<Table> TablePtr;
 typedef boost::shared_ptr<TableImpl> TableImplPtr;
+typedef std::map<std::string, int32_t(*)(Client*, int32_t, std::string*, ErrorCode*)> CommandTable_t;
 
 /// global variables of single-row-txn used in interactive mode
 tera::Transaction* g_row_txn = NULL;
 Table* g_row_txn_table = NULL;
+
+static CommandTable_t& GetCommandTable(){
+    static CommandTable_t command_table;
+    return command_table;
+}
 
 const char* builtin_cmd_list[] = {
     "create",
@@ -2171,7 +2178,7 @@ int32_t SafeModeOp(Client* client, int32_t argc, std::string* argv, ErrorCode* e
     return 0;
 }
 
-int32_t CookieOp(int32_t argc, std::string* argv) {
+int32_t CookieOp(Client*, int32_t argc, std::string* argv, ErrorCode*) {
     std::string command;
     if (argc == 4) {
         command = argv[2];
@@ -2833,7 +2840,7 @@ int32_t MetaOp(Client* client, int32_t argc, std::string* argv, ErrorCode* err) 
     return 0;
 }
 
-int32_t FindTabletOp(int32_t argc, std::string* argv, ErrorCode* err) {
+int32_t FindTabletOp(Client*, int32_t argc, std::string* argv, ErrorCode* err) {
     if ((argc != 4) && (argc != 5)) {
         PrintCmdHelpInfo(argv[1]);
         return -1;
@@ -2918,7 +2925,7 @@ int32_t FindTabletOp(int32_t argc, std::string* argv, ErrorCode* err) {
     return 0;
 }
 
-int32_t Meta2Op(Client *client, int32_t argc, std::string* argv) {
+int32_t Meta2Op(Client*, int32_t argc, std::string* argv, ErrorCode*) {
     if (argc < 3) {
         PrintCmdHelpInfo("meta");
         return -1;
@@ -3177,7 +3184,7 @@ int TxnOp(Client* client, int32_t argc, std::string* argv, ErrorCode* err) {
     }
 }
 
-int32_t HelpOp(int32_t argc, char** argv) {
+int32_t HelpOp(Client*, int32_t argc, std::string* argv, ErrorCode*) {
     if (argc == 2) {
         PrintAllCmd();
     } else if (argc == 3) {
@@ -3188,15 +3195,9 @@ int32_t HelpOp(int32_t argc, char** argv) {
     return 0;
 }
 
-int32_t HelpOp(int32_t argc, std::string* argv) {
-    if (argc == 2) {
-        PrintAllCmd();
-    } else if (argc == 3) {
-        PrintCmdHelpInfo(argv[2]);
-    } else {
-        PrintCmdHelpInfo("help");
-    }
-    return 0;
+int32_t HelpOp(int32_t argc, char** argv) {
+	std::vector<std::string> argv_svec(argv, argv + argc);
+    return HelpOp(NULL, argc, &argv_svec[0], NULL);
 }
 
 bool ParseCommand(int argc, char** arg_list, std::vector<std::string>* parsed_arg_list) {
@@ -3211,6 +3212,61 @@ bool ParseCommand(int argc, char** arg_list, std::vector<std::string>* parsed_ar
     return true;
 }
 
+static void InitializeCommandTable(){
+    CommandTable_t& command_table = GetCommandTable();
+    command_table["create"] = CreateOp;
+    command_table["createbyfile"] = CreateByFileOp;
+    command_table["update"] = UpdateOp;
+    command_table["update-check"] = UpdateCheckOp;
+    command_table["drop"] = DropOp;
+    command_table["enable"] = EnableOp;
+    command_table["disable"] = DisableOp;
+    command_table["show"] = ShowOp;
+    command_table["showx"] = ShowOp;
+    command_table["showall"] = ShowOp;
+    command_table["showschema"] = ShowSchemaOp;
+    command_table["showschemax"] = ShowSchemaOp;
+    command_table["showts"] = ShowTabletNodesOp;
+    command_table["showtsx"] = ShowTabletNodesOp;
+    command_table["put"] = PutOp;
+    command_table["putint64"] = PutInt64Op;
+    command_table["put-ttl"] = PutTTLOp;
+    command_table["put_counter"] = PutCounterOp;
+    command_table["add"] = AddOp;
+    command_table["addint64"] = AddInt64Op;
+    command_table["putif"] = PutIfAbsentOp;
+    command_table["append"] = AppendOp;
+    command_table["get"] = GetOp;
+    command_table["getint64"] = GetInt64Op;
+    command_table["get_counter"] = GetCounterOp;
+    command_table["delete"] = DeleteOp;
+    command_table["delete1v"] = DeleteOp;
+    command_table["batchput"] = BatchPutOp;
+    command_table["batchputint64"] = BatchPutInt64Op;
+    command_table["batchget"] = BatchGetOp;
+    command_table["batchgetint64"] = BatchGetInt64Op;
+    command_table["scan"] = ScanOp;
+    command_table["scanallv"] = ScanOp;
+    command_table["safemode"] = SafeModeOp;
+    command_table["tablet"] = TabletOp;
+    command_table["rename"] = RenameOp;
+    command_table["meta"] = MetaOp;
+    command_table["compact"] = CompactOp;
+    command_table["findmaster"] = FindMasterOp;
+    command_table["findts"] = FindTsOp;
+    command_table["findtablet"] = FindTabletOp;
+    command_table["meta2"] = Meta2Op;
+    command_table["user"] = UserOp;
+    command_table["reload"] = ReloadConfigOp;
+    command_table["kick"] = KickTabletServerOp;
+    command_table["cookie"] = CookieOp;
+    command_table["snapshot"] = SnapshotOp;
+    command_table["range"] = RangeOp;
+    command_table["rangex"] = RangeOp;
+    command_table["txn"] = TxnOp;
+	command_table["help"] = HelpOp;
+}
+
 int ExecuteCommand(Client* client, int argc, char** arg_list) {
     int ret = 0;
     ErrorCode error_code;
@@ -3219,105 +3275,21 @@ int ExecuteCommand(Client* client, int argc, char** arg_list) {
     if (!ParseCommand(argc, arg_list, &parsed_arg_list)) {
         return 1;
     }
-    std::string* argv = &parsed_arg_list[0];
 
+    std::string* argv = &parsed_arg_list[0];
     std::string cmd = argv[1];
-    if (cmd == "create") {
-        ret = CreateOp(client, argc, argv, &error_code);
-    } else if (cmd == "createbyfile") {
-        ret = CreateByFileOp(client, argc, argv, &error_code);
-    } else if (cmd == "update") {
-        ret = UpdateOp(client, argc, argv, &error_code);
-    } else if (cmd == "update-check") {
-        ret = UpdateCheckOp(client, argc, argv, &error_code);
-    } else if (cmd == "drop") {
-        ret = DropOp(client, argc, argv, &error_code);
-    } else if (cmd == "enable") {
-        ret = EnableOp(client, argc, argv, &error_code);
-    } else if (cmd == "disable") {
-        ret = DisableOp(client, argc, argv, &error_code);
-    } else if (cmd == "show" || cmd == "showx" || cmd == "showall") {
-        ret = ShowOp(client, argc, argv, &error_code);
-    } else if (cmd == "showschema" || cmd == "showschemax") {
-        ret = ShowSchemaOp(client, argc, argv, &error_code);
-    } else if (cmd == "showts" || cmd == "showtsx") {
-        ret = ShowTabletNodesOp(client, argc, argv, &error_code);
-    } else if (cmd == "put") {
-        ret = PutOp(client, argc, argv, &error_code);
-    } else if (cmd == "putint64") {
-        ret = PutInt64Op(client, argc, argv, &error_code);
-    } else if (cmd == "put-ttl") {
-        ret = PutTTLOp(client, argc, argv, &error_code);
-    } else if (cmd == "put_counter") {
-        ret = PutCounterOp(client, argc, argv, &error_code);
-    } else if (cmd == "add") {
-        ret = AddOp(client, argc, argv, &error_code);
-    } else if (cmd == "addint64") {
-        ret = AddInt64Op(client, argc, argv, &error_code);
-    } else if (cmd == "putif") {
-        ret = PutIfAbsentOp(client, argc, argv, &error_code);
-    } else if (cmd == "append") {
-        ret = AppendOp(client, argc, argv, &error_code);
-    } else if (cmd == "get") {
-        ret = GetOp(client, argc, argv, &error_code);
-    } else if (cmd == "getint64") {
-        ret = GetInt64Op(client, argc, argv, &error_code);
-    } else if (cmd == "get_counter") {
-        ret = GetCounterOp(client, argc, argv, &error_code);
-    } else if (cmd == "delete" || cmd == "delete1v") {
-        ret = DeleteOp(client, argc, argv, &error_code);
-    } else if (cmd == "batchput") {
-        ret = BatchPutOp(client, argc, argv, &error_code);
-    } else if (cmd == "batchputint64") {
-        ret = BatchPutInt64Op(client, argc, argv, &error_code);
-    } else if (cmd == "batchget") {
-        ret = BatchGetOp(client, argc, argv, &error_code);
-    } else if (cmd == "batchgetint64") {
-        ret = BatchGetInt64Op(client, argc, argv, &error_code);
-    } else if (cmd == "scan" || cmd == "scanallv") {
-        ret = ScanOp(client, argc, argv, &error_code);
-    } else if (cmd == "safemode") {
-        ret = SafeModeOp(client, argc, argv, &error_code);
-    } else if (cmd == "tablet") {
-        ret = TabletOp(client, argc, argv, &error_code);
-    } else if (cmd == "rename") {
-        ret = RenameOp(client, argc, argv, &error_code);
-    } else if (cmd == "meta") {
-        ret = MetaOp(client, argc, argv, &error_code);
-    } else if (cmd == "compact") {
-        ret = CompactOp(client, argc, argv, &error_code);
-    } else if (cmd == "findmaster") {
-        // get master addr(hostname:port)
-        ret = FindMasterOp(client, argc, argv, &error_code);
-    } else if (cmd == "findts") {
-        // get tabletnode addr from a key
-        ret = FindTsOp(client, argc, argv, &error_code);
-    } else if (cmd == "findtablet") {
-        ret = FindTabletOp(argc, argv, &error_code);
-    } else if (cmd == "meta2") {
-        ret = Meta2Op(client, argc, argv);
-    } else if (cmd == "user") {
-        ret = UserOp(client, argc, argv, &error_code);
-    } else if (cmd == "reload") {
-        ret = ReloadConfigOp(client, argc, argv, &error_code);
-    } else if (cmd == "kick") {
-        ret = KickTabletServerOp(client, argc, argv, &error_code);
-    } else if (cmd == "cookie") {
-        ret = CookieOp(argc, argv);
-    } else if (cmd == "snapshot") {
-        ret = SnapshotOp(client, argc, argv, &error_code);
-    } else if (cmd == "range" || cmd == "rangex") {
-        ret = RangeOp(client, argc, argv, &error_code);
-    } else if (cmd == "txn") {
-        ret = TxnOp(client, argc, argv, &error_code);
-    } else if (cmd == "version") {
+
+    CommandTable_t& command_table = GetCommandTable();
+
+    if (cmd == "version") {
         PrintSystemVersion();
-    } else if (cmd == "help") {
-        HelpOp(argc, argv);
+	} else if (command_table.find(cmd) != command_table.end()) {
+        command_table[cmd](client, argc, argv, &error_code);
     } else {
         PrintUnknownCmdHelpInfo(argv[1].c_str());
         ret = 1;
     }
+
     if (error_code.GetType() != ErrorCode::kOK) {
         LOG(ERROR) << "fail reason: " << error_code.ToString();
     }
@@ -3342,6 +3314,8 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     g_printer_opt.print_head = FLAGS_stdout_is_tty;
+
+	InitializeCommandTable();
 
     int ret  = 0;
     if (argc == 1) {


### PR DESCRIPTION
试用表驱动的方式实现“ExecuteCommand”，这样新加功能的话比较好管理，看起来也会整洁一些。但是由于需要使用 **std::map** 实现字符串到函数指针的映射，因此需要统一函数接口。有四个XXXOp的函数接口增加了1~2个参数，但函数本身没有用到。因此只留了形参定义，而没有命名。希望这是个更好的实现？: )

也许用一个聚合类封装所有参数会更好？

由于对boost的依赖，无法使用C++11，因此用不了**std::unordered_map**以及**std::function**，否则应该会更合逻辑一些。

另外注意到这次 **HelpOp** 有两个重载。因此让 ** (int32_t argc, char** argv) ** 去调用另一个版本了，消除重复代码。不知思路是否正确？