### PR TITLE
issue=#657 remove first query RPC for new tabletserver to speed up recovery

### DIFF
--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -357,13 +357,9 @@ private:
                                    QueryRequest* request,
                                    QueryResponse* response, bool failed,
                                    int error_code);
-    void TabletNodeRecoveryCallback(std::string addr, QueryRequest* request,
-                                    QueryResponse* response, bool failed,
-                                    int error_code);
     void RetryCollectTabletInfo(std::string addr,
                                 std::vector<TabletMeta>* tablet_list,
                                 sem_t* finish_counter, Mutex* mutex);
-    void RetryQueryNewTabletNode(std::string addr);
 
     void SplitTabletAsync(TabletPtr tablet);
     void SplitTabletCallback(TabletPtr tablet, SplitTabletRequest* request,

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -319,19 +319,20 @@ TabletNodeManager::~TabletNodeManager() {
     MutexLock lock(&mutex_);
 }
 
-void TabletNodeManager::AddTabletNode(const std::string& addr,
-                                      const std::string& uuid) {
+TabletNodePtr TabletNodeManager::AddTabletNode(const std::string& addr,
+                                               const std::string& uuid) {
     MutexLock lock(&mutex_);
     TabletNodePtr null_ptr;
     std::pair<TabletNodeList::iterator, bool> ret = tabletnode_list_.insert(
         std::pair<std::string, TabletNodePtr>(addr, null_ptr));
     if (!ret.second) {
         LOG(ERROR) << "tabletnode [" << addr << "] exists";
-        return;
+        return ret.first->second;
     }
     TabletNodePtr& state = ret.first->second;
     state.reset(new TabletNode(addr, uuid));
     LOG(INFO) << "add tabletnode : " << addr << ", id : " << uuid;
+    return state;
 }
 
 void TabletNodeManager::DelTabletNode(const std::string& addr) {

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -128,7 +128,7 @@ public:
     explicit TabletNodeManager(MasterImpl* master_impl);
     ~TabletNodeManager();
 
-    void AddTabletNode(const std::string& addr, const std::string& uuid);
+    TabletNodePtr AddTabletNode(const std::string& addr, const std::string& uuid);
     void DelTabletNode(const std::string& addr);
     void UpdateTabletNode(const std::string& addr, const TabletNode& info);
     bool FindTabletNode(const std::string& addr, TabletNodePtr* info);


### PR DESCRIPTION
#657 
query线程池调度时间过长，影响ts启动后tablet重新load