### PR TITLE
issue=#1209 the tabletserver who just starts is not a zombie

### DIFF
--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -22,6 +22,8 @@ TabletNode::TabletNode() : state_(kOffLine),
     update_time_(0), query_fail_count_(0), onload_count_(0),
     onsplit_count_(0), plan_move_in_count_(0) {
     info_.set_addr("");
+    info_.set_status_m(NodeStateToString(state_));
+    info_.set_timestamp(get_micros());
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
@@ -30,6 +32,8 @@ TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
       update_time_(0), query_fail_count_(0), onload_count_(0),
       onsplit_count_(0), plan_move_in_count_(0) {
     info_.set_addr(addr);
+    info_.set_status_m(NodeStateToString(state_));
+    info_.set_timestamp(get_micros());
 }
 
 TabletNode::TabletNode(const TabletNode& t) {


### PR DESCRIPTION
#1209  

https://github.com/baidu/tera/blob/0.5/src/teracli_main.cc#L1574

`info_`结构的`timestamp`字段一般被client/监控系统用来判断tabletserver的状态（如链接）；
刚启动（或重启）的tabletserver被master发现以后，还没来得及Query更新其信息之前，这个时候client或监控系统从master获取tabletserver信息时，拿到的`info_`结构的`timestamp`默认为0，误判为zombie.