### PR TITLE
issue=#1220 load current roll forward

### DIFF
--- a/src/io/test/load_test.cc
+++ b/src/io/test/load_test.cc
@@ -146,7 +146,8 @@ TEST_F(TabletIOTest, CurrentLost) {
     leveldb::Status s = leveldb::Env::Default()->NewLogger("./log/leveldblog", &ldb_logger);
     assert(s.ok());
 
-    ASSERT_FALSE(tablet.Load(TableSchema(), tablet_path, std::vector<uint64_t>(),
+    // if just lost the CURRENT, it will fix this issue
+    ASSERT_TRUE(tablet.Load(TableSchema(), tablet_path, std::vector<uint64_t>(),
                             empty_snaphsots_, empty_rollback_, ldb_logger, NULL, NULL, &status));
 
     env->ResetMock();


### PR DESCRIPTION
#1220

tablet第一次load时NewDB()会先生成manifest，再生成current。
如果生成manifest以后立刻就crash了，没来得及生成current. 此时重新load一次，当前的实现会认为current丢失了，拒绝load. 这种情况属于正常情形（预期内），应该要load起来.

这个pr的实现是：看到了manifest 并且 没有发现current，就将current设置指向最新manifest，尝试去load.
  - 对于第一次load到一半crash的情况：这种重置current的行为，相当于roll forward，第二次load完成了第一次的load本想做的事情，是正确的行为。
  - 对于current真的丢失的情况：
    - 只丢失current，重置current不会带来任何额外损失，从用户角度看没有任何数据损失。问题是可能隐藏了tera自己逻辑错误或文件系统异常，目前看没有非常简单的解决方案，这里打出了异常日志，供后续分析
    - 丢失了很多文件，其中包括current. 后续读出manifest后会和文件系统上的文件list对比，如果真有数据损失，会报出来，不会悄悄损失数据。

综上，这个方法符合2个原则：
1. 默认强一致，未经用户知晓不会容错，能自动load起来即说明用户数据本身完好无损
2. 自动化处理预期内的异常（load到一半还没生成current即宕掉）

也有一个问题：
可能隐藏tera自己逻辑错误或文件系统异常，但即便有这些异常，也没有影响到用户数据。这块没想到简单可行的方案。