### PR TITLE
issue=#981 fix rpc resolve address

### DIFF
--- a/src/proto/rpc_client.h
+++ b/src/proto/rpc_client.h
@@ -41,6 +41,7 @@ class RpcClientBase {
 public:
     static void SetOption(int32_t max_inflow, int32_t max_outflow,
                           int32_t pending_buffer_size, int32_t thread_num) {
+        channel_options_.create_with_init = false;
         if (-1 != max_inflow) {
             rpc_client_options_.max_throughput_in = max_inflow;
         }
@@ -75,9 +76,15 @@ protected:
         if (it != rpc_channel_list_.end()) {
             rpc_channel_ = it->second;
         } else {
-            rpc_channel_ = rpc_channel_list_[server_addr]
-                = new sofa::pbrpc::RpcChannel(&rpc_client_, server_addr,
-                                              channel_options_);
+            sofa::pbrpc::RpcChannel* c = new sofa::pbrpc::RpcChannel(&rpc_client_,
+                                                                     server_addr,
+                                                                     channel_options_);
+            if (c->Init()) {
+                rpc_channel_ = rpc_channel_list_[server_addr] = c;
+            } else {
+                delete c;
+                rpc_channel_ = NULL;
+            }
         }
         mutex_.Unlock();
     }
@@ -119,7 +126,11 @@ protected:
         }
         */
         RpcClientBase::ResetClient(server_addr);
-        server_client_.reset(new ServerType(rpc_channel_));
+        if (rpc_channel_ == NULL) {
+            server_client_.reset(NULL);
+        } else {
+            server_client_.reset(new ServerType(rpc_channel_));
+        }
         server_addr_ = server_addr;
         // VLOG(5) << "reset connected address to: " << server_addr;
     }


### PR DESCRIPTION
#981 

之前版本的rpc client，如果初始化rpc channel时出错，后续这个channel上的rpc调用都会失败。需要用户重新构造channel。

解决：新版rpc（1.1.3及以上）提供了init接口，用户手动调用判断channel初始化（地址解析）是否成功，如果失败则下次重新解析。