### PR TITLE
bugfix: teracli create binary table without cf

### DIFF
--- a/src/io/tablet_io.cc
+++ b/src/io/tablet_io.cc
@@ -285,7 +285,8 @@ bool TabletIO::Load(const TableSchema& schema,
     }
 
     tablet_path_ = path_prefix + path;
-    LOG(INFO) << "[Load] Start Open " << tablet_path_;
+    LOG(INFO) << "[Load] Start Open " << tablet_path_
+        << ", kv_only " << kv_only_ << ", raw_key_operator " << key_operator_->Name();
     // recover snapshot
     for (std::map<uint64_t, uint64_t>::iterator it = snapshots.begin(); it != snapshots.end(); ++it) {
         id_to_snapshot_num_[it->first] = it->second;

--- a/src/leveldb/include/leveldb/raw_key_operator.h
+++ b/src/leveldb/include/leveldb/raw_key_operator.h
@@ -29,6 +29,7 @@ public:
                                 TeraKeyType* type) const = 0;
     virtual int Compare(const Slice& key1,
                         const Slice& key2) const = 0;
+    virtual const char* Name() const = 0;
 };
 
 const RawKeyOperator* ReadableRawKeyOperator();

--- a/src/leveldb/util/raw_key_operator.cc
+++ b/src/leveldb/util/raw_key_operator.cc
@@ -102,6 +102,10 @@ public:
     virtual int Compare(const Slice& key1, const Slice& key2) const {
         return key1.compare(key2);
     }
+
+    const char* Name() const {
+        return "tera.RawKeyOperator.readable";
+    }
 };
 
 /**
@@ -228,6 +232,10 @@ public:
         Slice ts_type2(data2 + size2 - 12, 8);
         return ts_type1.compare(ts_type2);
     }
+
+    const char* Name() const {
+        return "tera.RawKeyOperator.binary";
+    }
 };
 
 // support KV-pair with TTL, Key's format :
@@ -266,6 +274,10 @@ public:
         leveldb::Slice key1_rowkey(key1.data(), key1.size() - sizeof(int64_t));
         leveldb::Slice key2_rowkey(key2.data(), key2.size() - sizeof(int64_t));
         return key1_rowkey.compare(key2_rowkey);
+    }
+
+    const char* Name() const {
+        return "tera.RawKeyOperator.kv";
     }
 };
 

--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -564,6 +564,15 @@ bool CheckTableDescrptor(const TableDescriptor& desc, ErrorCode* err) {
         }
         return false;
     }
+    if ((desc.RawKey() == kReadable || desc.RawKey() == kBinary)) {
+        if (desc.ColumnFamilyNum() == 0) {
+            ss << "kBinary/kReadable MUST have cf";
+            if (err != NULL) {
+                err->SetFailed(ErrorCode::kBadParam, ss.str());
+            }
+            return false;
+        }
+    }
     return true;
 }
 

--- a/src/utils/string_util.cc
+++ b/src/utils/string_util.cc
@@ -151,7 +151,7 @@ bool IsValidName(const std::string& str) {
     for (size_t i = 0; i < str.size(); ++i) {
         char c = str[i];
         if (!(isdigit(c) || isupper(c) || islower(c)
-              || (c == '_') || (c == '.') || (c == '-'))) {
+              || (c == '_') || (c == '.') || (c == '-') || (c == '#'))) {
             return false;
         }
     }


### PR DESCRIPTION
tablet writer use kv format to set tera key, but use table format to read tera key; cause key format error.