### PR TITLE
issue=#877 txn with write-timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ tablet_io_test: src/sdk/tera.o src/io/test/tablet_io_test.o src/tabletnode/table
                 $(IO_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LEVELDB_LIB)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
-load_test: src/io/test/load_test.o src/tabletnode/tabletnode_sysinfo.o \
+load_test: src/sdk/tera.o src/io/test/load_test.o src/tabletnode/tabletnode_sysinfo.o \
                 $(IO_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LEVELDB_LIB)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
@@ -184,7 +184,7 @@ fragment_test: src/utils/test/fragment_test.o src/utils/fragment.o
 progress_bar_test: src/common/console/progress_bar_test.o src/common/console/progress_bar.o
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
-tablet_scanner_test: src/io/test/tablet_scanner_test.o src/tabletnode/tabletnode_sysinfo.o \
+tablet_scanner_test: src/sdk/tera.o src/io/test/tablet_scanner_test.o src/tabletnode/tabletnode_sysinfo.o \
                      $(IO_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LEVELDB_LIB)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ tprinter_test: src/utils/test/tprinter_test.o $(LIBRARY)
 string_util_test: src/utils/test/string_util_test.o $(LIBRARY)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
-tablet_io_test: src/io/test/tablet_io_test.o src/tabletnode/tabletnode_sysinfo.o \
+tablet_io_test: src/sdk/tera.o src/io/test/tablet_io_test.o src/tabletnode/tabletnode_sysinfo.o \
                 $(IO_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LEVELDB_LIB)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 


### PR DESCRIPTION
#877 事务表也支持用户指定写入的时间戳（版本号）

对于事务表：如果用户带了时间戳，则必须使用用户指定的时间戳（多行事务场景TimeOracle通过单行事务指定自己的版本号）；如果用户没有带时间戳（tera sdk设置默认值kLatestTimestamp），这个时候使用server分配的。