### PR TITLE
Minor bug fix for shell scripts like `kill_tera.sh`, `launch_tera.sh` and teracli

### DIFF
--- a/build.conf.template
+++ b/build.conf.template
@@ -18,6 +18,7 @@ LIBUNWIND_VERSION=0.99
 GPERFTOOLS_VERSION=2.5
 INS_VERSION=0.15
 NOSE_VERSION=1.3.7
+READLINE_VERSION=7.0
 
 if [ $MIRROR == "china" ]; then
     BOOST_URL=http://mirrors.tuna.tsinghua.edu.cn/macports/distfiles/boost/boost_${BOOST_VERSION}.tar.bz2
@@ -32,6 +33,7 @@ if [ $MIRROR == "china" ]; then
     GPERFTOOLS_URL=https://github.com/00k/gperftools/raw/master/gperftools-${GPERFTOOLS_VERSION}.tar.gz
     INS_URL=https://github.com/baidu/ins/archive/${INS_VERSION}.tar.gz
     NOSE_URL=http://mirrors.163.com/gentoo/distfiles/nose-${NOSE_VERSION}.tar.gz
+    READLINE_URL=http://git.savannah.gnu.org/cgit/readline.git/snapshot/readline-${READLINE_VERSION}.tar.gz
 elif [ $MIRROR == "origin" ]; then
     BOOST_URL=http://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_${BOOST_VERSION}.tar.bz2
     PROTOBUF_URL=https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-${PROTOBUF_VERSION}.tar.bz2
@@ -45,6 +47,7 @@ elif [ $MIRROR == "origin" ]; then
     GPERFTOOLS_URL=https://github.com/gperftools/gperftools/releases/download/gperftools-${GPERFTOOLS_VERSION}/gperftools-${GPERFTOOLS_VERSION}.tar.gz
     INS_URL=https://github.com/baidu/ins/archive/${INS_VERSION}.tar.gz
     NOSE_URL=https://pypi.python.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-${NOSE_VERSION}.tar.gz
+    READLINE_URL=http://git.savannah.gnu.org/cgit/readline.git/snapshot/readline-${READLINE_VERSION}.tar.gz
 elif [ $MIRROR == "baidu" ]; then
     BOOST_URL=http://gitlab.baidu.com/baidups/third/raw/master/boost_${BOOST_VERSION}.tar.bz2
     PROTOBUF_URL=http://gitlab.baidu.com/baidups/third/raw/master/protobuf-${PROTOBUF_VERSION}.tar.bz2
@@ -58,6 +61,7 @@ elif [ $MIRROR == "baidu" ]; then
     GPERFTOOLS_URL=http://gitlab.baidu.com/baidups/third/raw/master/gperftools-${GPERFTOOLS_VERSION}.tar.gz
     INS_URL=http://gitlab.baidu.com/baidups/third/raw/master/ins-${INS_VERSION}.tar.gz
     NOSE_URL=http://gitlab.baidu.com/baidups/third/raw/master/nose-${NOSE_VERSION}.tar.gz
+    READLINE_URL=http://git.savannah.gnu.org/cgit/readline.git/snapshot/readline-${READLINE_VERSION}.tar.gz
 else
     return 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -223,7 +223,7 @@ if [ ${NOSE_VERSION} == "DISABLE" ]; then
     echo "Disable nose."
 elif [ ! -f "${FLAG_DIR}/nose_${NOSE_VERSION}" ] \
     || [ ! -f "${DEPS_PREFIX}/bin/nosetests" ] \
-    || [ ! -d "${DEPS_PREFIX}/lib/nose" ]; then
+    || [ ! -d "${DEPS_PREFIX}/lib/"nose* ]; then
     wget --no-check-certificate -O nose-${NOSE_VERSION}.tar.gz ${NOSE_URL}
     tar zxf nose-${NOSE_VERSION}.tar.gz --recursive-unlink
     cd nose-${NOSE_VERSION}
@@ -231,6 +231,21 @@ elif [ ! -f "${FLAG_DIR}/nose_${NOSE_VERSION}" ] \
     python setup.py install --prefix=. --install-scripts=${DEPS_PREFIX}/bin --install-lib=${DEPS_PREFIX}/lib
     cd -
     touch "${FLAG_DIR}/nose_${NOSE_VERSION}"
+fi
+
+# readline (teracli_main.cc use this and lead to compile failed)
+if [ ${READLINE_VERSION} == "DISABLE" ]; then
+    echo "Disable readline."
+elif [ ! -f "${FLAG_DIR}/readline_${READLINE_VERSION}" ] \
+    || [ ! -f "${DEPS_PREFIX}/lib/libreadline.a" ] \
+    || [ ! -d "${DEPS_PREFIX}/include/readline" ]; then
+    wget --no-check-certificate -O readline-${READLINE_VERSION}.tar.gz ${READLINE_URL}
+    tar zxf readline-${READLINE_VERSION}.tar.gz --recursive-unlink
+    cd readline-${READLINE_VERSION}
+    ./configure ${DEPS_CONFIG} CPPFLAGS=-I${DEPS_PREFIX}/include LDFLAGS=-L${DEPS_PREFIX}/lib
+    make install
+    cd -
+    touch "${FLAG_DIR}/readline_${READLINE_VERSION}"
 fi
 
 cd ${WORK_DIR}

--- a/example/onebox/bin/kill_tera.sh
+++ b/example/onebox/bin/kill_tera.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-source ./config
+CURRENT_DIR=`dirname $0`
+source ${CURRENT_DIR}/config
 
 PID=`ps x | grep tera_master | grep $PORT | awk '{print $1}'`;
 if [ ${PID}"x" != "x" ]; then

--- a/example/onebox/bin/launch_tera.sh
+++ b/example/onebox/bin/launch_tera.sh
@@ -3,7 +3,7 @@ CURRENT_DIR=`dirname $0`
 source ${CURRENT_DIR}/config
 
 # make sure tera is killed
-./kill_tera.sh
+./$CURRENT_DIR/kill_tera.sh
 
 FAKE_ZK_PATH_PREFIX="${CURRENT_DIR}/../fakezk"
 TIME=`date +%Y-%m-%d-%H:%M:%S`

--- a/src/common/file/file_path.cc
+++ b/src/common/file/file_path.cc
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include <gflags/gflags.h>
 
@@ -104,6 +105,23 @@ bool CreateDirWithRetry(const std::string& dir_path) {
         }
     }
     return is_success;
+}
+std::string GetCWD(){
+    char buf[1024];
+    if(getcwd(buf, 1024) == NULL){
+        return "";
+    }
+	return buf;
+}
+
+std::string GetProcessDir(){
+    char buf[1024];
+    ssize_t count = readlink("/proc/self/exe", buf, 1024);
+    if(count == 0) {
+        return "";
+    } else{
+    return dirname(buf);
+    }
 }
 
 std::string UidToName(uid_t uid) {

--- a/src/common/file/file_path.h
+++ b/src/common/file/file_path.h
@@ -21,6 +21,9 @@ std::string GetPathPrefix(const std::string& full_path,
 
 bool CreateDirWithRetry(const std::string& dir_path);
 
+std::string GetCWD();
+std::string GetProcessDir();
+
 std::string GidToName(gid_t gid);
 
 std::string UidToName(uid_t uid);

--- a/src/sdk/client_impl.cc
+++ b/src/sdk/client_impl.cc
@@ -1207,16 +1207,16 @@ static int InitFlags(const std::string& confpath, const std::string& log_prefix)
     } else if (!FLAGS_tera_sdk_conf_file.empty() && !IsExist(confpath)) {
         LOG(ERROR) << "specified config file(FLAGS_tera_sdk_conf_file) not found";
         return -1;
-    } else if (IsExist("./tera.flag")) {
+    } else if (IsExist(GetProcessDir()+"./tera.flag")) {
         flagfile = "./tera.flag";
-    } else if (IsExist("../conf/tera.flag")) {
+    } else if (IsExist(GetProcessDir()+"/../conf/tera.flag")) {
         flagfile = "../conf/tera.flag";
     } else if (IsExist(utils::GetValueFromEnv("TERA_CONF"))) {
         flagfile = utils::GetValueFromEnv("TERA_CONF");
     } else {
         LOG(ERROR) << "hasn't specify the flagfile, but default config file not found";
         return -1;
-    }
+        }
 
     utils::LoadFlagFile(flagfile);
 


### PR DESCRIPTION
(#1279)
1. add readline download link to avoid compile error (`build.conf.template` and `build.sh`.
2. run the shell with CURRENT_DIRECTORY, to avoid the error like `bin/kill_tera.sh`.
3. add GetProcessDir function to get the exe directory, so that we can run `teracli` in any directory, rather than only work by `./teracli`.